### PR TITLE
Corrected Duplicate SIDs (#5)

### DIFF
--- a/fortinet-648.rules
+++ b/fortinet-648.rules
@@ -30,135 +30,135 @@
 # These are mostly taken from Fortigate 6.4.8 Message reference manual.
 #Written by Charles Goggins - Quadrant Information Security
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] IPS Session Scan Paused"; content: "logid=|22|0100022700|22|"; content: "type="; content: "subtype="; classtype: system-error; reference: url,wiki.quadrantsec.com/bin/view/Main/5000898; sid: 5000898; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] IPS Session Scan Paused"; content: "logid=|22|0100022700|22|"; content: "type="; content: "subtype="; classtype: system-error; reference: url,wiki.quadrantsec.com/bin/view/Main/5006040; sid: 5006040; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Compromised Host Detected"; content: "logid=|22|0100022953|22|"; content: "type="; content: "subtype="; classtype: malware; reference: url,wiki.quadrantsec.com/bin/view/Main/5000899; sid: 5000899; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Compromised Host Detected"; content: "logid=|22|0100022953|22|"; content: "type="; content: "subtype="; classtype: malware; reference: url,wiki.quadrantsec.com/bin/view/Main/5006041; sid: 5006041; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] FortiGuard Message Service Status"; content: "logid=|22|0100022916|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000900; sid: 5000900; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] FortiGuard Message Service Status"; content: "logid=|22|0100022916|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006042; sid: 5006042; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] IPv6 firewall inbound policy added"; content: "logid=|22|0100032151|22|"; content: "type="; content: "subtype="; classtype: configuration-change; reference: url,wiki.quadrantsec.com/bin/view/Main/5000901; sid: 5000901
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] IPv6 firewall inbound policy added"; content: "logid=|22|0100032151|22|"; content: "type="; content: "subtype="; classtype: configuration-change; reference: url,wiki.quadrantsec.com/bin/view/Main/5006043; sid: 5006043; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Successful Admin Login"; content: "logid=|22|0100032001|22|"; content: "type="; content: "subtype="; classtype: successful-admin; reference: url,wiki.quadrantsec.com/bin/view/Main/5000902; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000902; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Successful Admin Login"; content: "logid=|22|0100032001|22|"; content: "type="; content: "subtype="; classtype: successful-admin; reference: url,wiki.quadrantsec.com/bin/view/Main/5006044; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006044; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin Login Failed"; content: "logid=|22|0100032002|22|"; content: "type="; content: "subtype="; classtype: attempted-admin; reference: url,wiki.quadrantsec.com/bin/view/Main/5000903; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000903; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin Login Failed"; content: "logid=|22|0100032002|22|"; content: "type="; content: "subtype="; classtype: attempted-admin; reference: url,wiki.quadrantsec.com/bin/view/Main/5006045; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006045; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin logout successful"; content: "logid=|22|0100032003|22|"; content: "type="; content: "subtype="; classtype: not-suspicious; reference: url,wiki.quadrantsec.com/bin/view/Main/5000904; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000904; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin logout successful"; content: "logid=|22|0100032003|22|"; content: "type="; content: "subtype="; classtype: not-suspicious; reference: url,wiki.quadrantsec.com/bin/view/Main/5006046; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006046; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] VDOM overwritten by Admin"; content: "logid=|22|0100032005|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000905; sid: 5000905; rev:12;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] VDOM overwritten by Admin"; content: "logid=|22|0100032005|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006047; sid: 5006047; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Super admin entered VDOM"; content: "logid=|22|0100032006|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000906; sid: 5000906; rev:4;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Super admin entered VDOM"; content: "logid=|22|0100032006|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006048; sid: 5006048; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Super admin left VDOM"; content: "logid=|22|0100032007|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000907; sid: 5000907; rev:4;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Super admin left VDOM"; content: "logid=|22|0100032007|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006049; sid: 5006049; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] FortiGate Started"; content: "logid=|22|0100032009|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000908; sid: 5000908; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] FortiGate Started"; content: "logid=|22|0100032009|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006050; sid: 5006050; rev:31)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Logs deleted by user"; content: "logid=|22|0100032044|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000909; sid: 5000909; rev:5;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Logs deleted by user"; content: "logid=|22|0100032044|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006051; sid: 5006051; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Support License expiring"; content: "logid=|22|0100032014|22|"; content: "type="; content: "subtype="; classtype: program-error; reference: url,wiki.quadrantsec.com/bin/view/Main/5000910; sid: 5000910; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Support License expiring"; content: "logid=|22|0100032014|22|"; content: "type="; content: "subtype="; classtype: program-error; reference: url,wiki.quadrantsec.com/bin/view/Main/5006052; sid: 5006052; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Corrupted MAC packet detected"; content: "logid=|22|0100032020|22|"; content: "type="; content: "subtype="; classtype: network-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000911; sid: 5000911; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Corrupted MAC packet detected"; content: "logid=|22|0100032020|22|"; content: "type="; content: "subtype="; classtype: network-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006053; sid: 5006053; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin Performed Action from GUI"; content: "logid=|22|0100032095|22|"; content: "type="; content: "subtype="; classtype: configuration-change; reference: url,wiki.quadrantsec.com/bin/view/Main/5000912; sid: 5000912; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin Performed Action from GUI"; content: "logid=|22|0100032095|22|"; content: "type="; content: "subtype="; classtype: configuration-change; reference: url,wiki.quadrantsec.com/bin/view/Main/5006054; sid: 5006054; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Configuration change"; content: "logid=|22|0100032102|22|"; content: "type="; content: "subtype="; classtype: configuration-change; reference: url,wiki.quadrantsec.com/bin/view/Main/5000913; sid: 5000913; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Configuration change"; content: "logid=|22|0100032102|22|"; content: "type="; content: "subtype="; classtype: configuration-change; reference: url,wiki.quadrantsec.com/bin/view/Main/5006055; sid: 5006055; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] New Firmware Available on FortiGuard"; content: "logid=|22|0100032103|22|"; content: "type="; content: "subtype="; classtype: not-suspicious; reference: url,wiki.quadrantsec.com/bin/view/Main/5000914; sid: 5000914; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] New Firmware Available on FortiGuard"; content: "logid=|22|0100032103|22|"; content: "type="; content: "subtype="; classtype: not-suspicious; reference: url,wiki.quadrantsec.com/bin/view/Main/5006056; sid: 5006056; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin Password Expired"; content: "logid=|22|0100032024|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000915; sid: 5000915; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin Password Expired"; content: "logid=|22|0100032024|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006057; sid: 5006057; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] L2TP/PPTP/PPPoE Authentication success"; content: "logid=|22|0100029002|22|"; content: "type="; content: "subtype="; classtype: successful-user; reference: url,wiki.quadrantsec.com/bin/view/Main/5000916; sid: 5000916; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] L2TP/PPTP/PPPoE Authentication success"; content: "logid=|22|0100029002|22|"; content: "type="; content: "subtype="; classtype: successful-user; reference: url,wiki.quadrantsec.com/bin/view/Main/5006058; sid: 5006058; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] L2TP/PPTP/PPPoE Authentication failed"; content: "logid=|22|0100029003|22|"; content: "type="; content: "subtype="; classtype: unsuccessful-user; reference: url,wiki.quadrantsec.com/bin/view/Main/5000917; sid: 5000917; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] L2TP/PPTP/PPPoE Authentication failed"; content: "logid=|22|0100029003|22|"; content: "type="; content: "subtype="; classtype: unsuccessful-user; reference: url,wiki.quadrantsec.com/bin/view/Main/5006059; sid: 5006059; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] L2TP/PPTP/PPPoE Max connection reached"; content: "logid=|22|0101040014|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000918; sid: 5000918; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] L2TP/PPTP/PPPoE Max connection reached"; content: "logid=|22|0101040014|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006060; sid: 5006060; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Data Leak Prevention Rule Matched"; content: "logid=|22|0954024576|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5000919; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000919; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Data Leak Prevention Rule Matched"; content: "logid=|22|0954024576|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5006061; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006061; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Application control instant messaging message"; content: "logid=|22|1059028672|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5000920; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000920; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Application control instant messaging message"; content: "logid=|22|1059028672|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5006062; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006062; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Application control instant message - file tranfer message"; content: "logid=|22|1059028675|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5000921; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000921; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Application control instant message - file tranfer message"; content: "logid=|22|1059028675|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5006063; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006063; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Application control instant message chat message"; content: "logid=|22|1059028676|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5000922; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000922; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Application control instant message chat message"; content: "logid=|22|1059028676|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5006064; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006064; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] VoIP-SIP session blocked"; content: "logid=|2|0814044033|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5000923; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000923; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] VoIP-SIP session blocked"; content: "logid=|2|0814044033|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5006065; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006065; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Infected File Detected Within Email"; content: "logid=|22|0211008194|22|"; content: "type="; content: "subtype="; classtype: suspicious-traffic; reference: url,wiki.quadrantsec.com/bin/view/Main/5000924; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000924; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Infected File Detected Within Email"; content: "logid=|22|0211008194|22|"; content: "type="; content: "subtype="; classtype: suspicious-traffic; reference: url,wiki.quadrantsec.com/bin/view/Main/5006066; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006066; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack Detected by UDP/TCP Signature"; content: "logid=|22|0419016384|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5000925; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000925; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack Detected by UDP/TCP Signature"; content: "logid=|22|0419016384|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5006067; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006067; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack detected by ICMP Signature"; content: "logid=|22|0419016385|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5000926; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000926; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack detected by ICMP Signature"; content: "logid=|22|0419016385|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5006068; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006068; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack detected by Other Signature"; content: "logid=|22|0419016386|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5000927; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000927; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack detected by Other Signature"; content: "logid=|22|0419016386|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5006069; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006069; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack detected by Malicious URL"; content: "logid=|22|0421016399|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5000928; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000928; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack detected by Malicious URL"; content: "logid=|22|0421016399|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5006070; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006070; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Botnet C&C Communication - Warning"; content: "logid=|22|0402016400|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5000929; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000929; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Botnet C&C Communication - Warning"; content: "logid=|22|0402016400|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5006071; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006071; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Web - Banned word was found"; content: "logid=|22|0314012288|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5000930; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000930; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Web - Banned word was found"; content: "logid=|22|0314012288|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5006072; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006072; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Cookie Removed Entirely"; content: "logid=|22|0336013601|22|"; content: "type="; content: "subtype="; classtype: web-application-activity; reference: url,wiki.quadrantsec.com/bin/view/Main/5000931; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000931; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Cookie Removed Entirely"; content: "logid=|22|0336013601|22|"; content: "type="; content: "subtype="; classtype: web-application-activity; reference: url,wiki.quadrantsec.com/bin/view/Main/5006073; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006073; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Cookie Removed"; content: "logid=|22|0336013573|22|"; content: "type="; content: "subtype="; classtype: web-application-activity; reference: url,wiki.quadrantsec.com/bin/view/Main/5000932; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000932; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Cookie Removed"; content: "logid=|22|0336013573|22|"; content: "type="; content: "subtype="; classtype: web-application-activity; reference: url,wiki.quadrantsec.com/bin/view/Main/5006074; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006074; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Java applet was removed"; content: "logid=|22|0337013584|22|"; content: "type="; content: "subtype="; classtype: web-application-activity; reference: url,wiki.quadrantsec.com/bin/view/Main/5000933; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000933; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Java applet was removed"; content: "logid=|22|0337013584|22|"; content: "type="; content: "subtype="; classtype: web-application-activity; reference: url,wiki.quadrantsec.com/bin/view/Main/5006075; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006075; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] ActiveX script was removed"; content: "logid=|22|0335013568|22|"; content: "type="; content: "subtype="; classtype: web-application-activity; reference: url,wiki.quadrantsec.com/bin/view/Main/5000934; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000934; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] ActiveX script was removed"; content: "logid=|22|0335013568|22|"; content: "type="; content: "subtype="; classtype: web-application-activity; reference: url,wiki.quadrantsec.com/bin/view/Main/5006076; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006076; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Script Entity Removed"; content: "logid=|22|0341013600|22|"; content: "type="; content: "subtype="; classtype: web-application-activity; reference: url,wiki.quadrantsec.com/bin/view/Main/5000935; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000935; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Script Entity Removed"; content: "logid=|22|0341013600|22|"; content: "type="; content: "subtype="; classtype: web-application-activity; reference: url,wiki.quadrantsec.com/bin/view/Main/5006077; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006077; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] URL Blocked per Filter"; content: "logid=|22|0315012544|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5000936; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000936; rev:2;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] URL Blocked per Filter"; content: "logid=|22|0315012544|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5006078; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006078; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] URL Exempt per Filter"; content: "logid=|22|0315012545|22|"; content: "type="; content: "subtype="; classtype: not-suspicious; reference: url,wiki.quadrantsec.com/bin/view/Main/5000937; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000937; rev:2;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] URL Exempt per Filter"; content: "logid=|22|0315012545|22|"; content: "type="; content: "subtype="; classtype: not-suspicious; reference: url,wiki.quadrantsec.com/bin/view/Main/5006079; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006079; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] URL Allowed per Filter"; content: "logid=|22|0315012546|22|"; content: "type="; content: "subtype="; classtype: not-suspicious; reference: url,wiki.quadrantsec.com/bin/view/Main/5000938; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000938; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] URL Allowed per Filter"; content: "logid=|22|0315012546|22|"; content: "type="; content: "subtype="; classtype: not-suspicious; reference: url,wiki.quadrantsec.com/bin/view/Main/5006080; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006080; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] URL Belongs to Blocked Category Within Firewall Policy"; content: "logid=|22|0316013056|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5000939; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000939; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] URL Belongs to Blocked Category Within Firewall Policy"; content: "logid=|22|0316013056|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5006081; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006081; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] URL Belongs to Allowed Category Within Firewall Policy"; content: "logid=|22|0317013312|22|"; content: "type="; content: "subtype="; classtype: not-suspicious; reference: url,wiki.quadrantsec.com/bin/view/Main/5000940; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000940; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] URL Belongs to Allowed Category Within Firewall Policy"; content: "logid=|22|0317013312|22|"; content: "type="; content: "subtype="; classtype: not-suspicious; reference: url,wiki.quadrantsec.com/bin/view/Main/5006082; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006082; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET]  Outdated Report Files Deleted"; content: "logid=|22|0100020027|22|"; content: "type="; content: "subtype="; classtype: system-event; threshold: type limit, track by_src, count 1, seconds 86400; reference: url,wiki.quadrantsec.com/bin/view/Main/5000941; sid: 5000941; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET]  Outdated Report Files Deleted"; content: "logid=|22|0100020027|22|"; content: "type="; content: "subtype="; classtype: system-event; threshold: type limit, track by_src, count 1, seconds 86400; reference: url,wiki.quadrantsec.com/bin/view/Main/5006083; sid: 5006083; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET]  Disk Log File Deleted"; content: "logid=|22|0100032029|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000942; sid: 5000942; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET]  Disk Log File Deleted"; content: "logid=|22|0100032029|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006084; sid: 5006084; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET]  New SSL VPN Connection"; content: "logid=|22|0101039943|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000943; parse_src_ip: 1; sid: 5000943; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET]  New SSL VPN Connection"; content: "logid=|22|0101039943|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006085; parse_src_ip: 1; sid: 5006085; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET]  SSL Decryption Failed"; content: "logid=|22|0105048009|22|"; content: "type="; content: "subtype="; classtype: system-error; reference: url,wiki.quadrantsec.com/bin/view/Main/5000944; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000944; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET]  SSL Decryption Failed"; content: "logid=|22|0105048009|22|"; content: "type="; content: "subtype="; classtype: system-error; reference: url,wiki.quadrantsec.com/bin/view/Main/5006086; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006086; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] SSL VPN Alert"; content: "logid=|22|0101039944|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000945; parse_src_ip: 1; sid: 5000945; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] SSL VPN Alert"; content: "logid=|22|0101039944|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006087; parse_src_ip: 1; sid: 5006087; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] SSL Fatal Alert Received"; content: "logid=|22|0105048038|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000946; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000946; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] SSL Fatal Alert Received"; content: "logid=|22|0105048038|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006088; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006088; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Authentication Logon"; content: "logid=|22|0102043039|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000947; parse_src_ip: 1; sid: 5000947; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Authentication Logon"; content: "logid=|22|0102043039|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006089; parse_src_ip: 1; sid: 5006089; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Authentication Logout"; content: "logid=|22|0102043040|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000948; parse_src_ip: 1; sid: 5000948; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Authentication Logout"; content: "logid=|22|0102043040|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006090; parse_src_ip: 1; sid: 5006090; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Report Deleted"; content: "logid=|22|0100032040|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000949; sid: 5000949; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Report Deleted"; content: "logid=|22|0100032040|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006091; sid: 5006091; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin Monitor login Successful"; content: "logid=|22|0100032053|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000950; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000950; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin Monitor login Successful"; content: "logid=|22|0100032053|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006092; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006092; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Infected File Detected"; content: "logid=|22|0211008192|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000951; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000951; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Infected File Detected"; content: "logid=|22|0211008192|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006093; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006093; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Virus Command Blocked"; content: "logid=|22|0206008452|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000952; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000952; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Virus Command Blocked"; content: "logid=|22|0206008452|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006094; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006094; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] App-Control IPS Pass"; content: "logid=|22|1059028704|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000953; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000953; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] App-Control IPS Pass"; content: "logid=|22|1059028704|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006095; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006095; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] App-Control IPS Block"; content: "logid=|22|1059028705|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000954; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000954; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] App-Control IPS Block"; content: "logid=|22|1059028705|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006096; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006096; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] SSL Certificate Anomaly - Blocked"; content: "logid=|22|1700062303|22|"; content: "type="; content: "subtype="; classtype: suspicious-traffic; reference: url,wiki.quadrantsec.com/bin/view/Main/5000955; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000955; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] SSL Certificate Anomaly - Blocked"; content: "logid=|22|1700062303|22|"; content: "type="; content: "subtype="; classtype: suspicious-traffic; reference: url,wiki.quadrantsec.com/bin/view/Main/5006097; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006097; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] SSL Certificate Anomaly - Blacklisted"; content: "logid=|22|1700062300|22|"; content: "type="; content: "subtype="; classtype: suspicious-traffic; reference: url,wiki.quadrantsec.com/bin/view/Main/5000956; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000956; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] SSL Certificate Anomaly - Blacklisted"; content: "logid=|22|1700062300|22|"; content: "type="; content: "subtype="; classtype: suspicious-traffic; reference: url,wiki.quadrantsec.com/bin/view/Main/5006098; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006098; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] SSL Certificate Anomaly - SNI Mismatched"; content: "logid=|22|1700062304|22|"; content: "type="; content: "subtype="; classtype: suspicious-traffic; reference: url,wiki.quadrantsec.com/bin/view/Main/5000957; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000957; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] SSL Certificate Anomaly - SNI Mismatched"; content: "logid=|22|1700062304|22|"; content: "type="; content: "subtype="; classtype: suspicious-traffic; reference: url,wiki.quadrantsec.com/bin/view/Main/5006099; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006099; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] DNS - Domain Belongs to a Denied Category in Policy"; content: "logid=|22|1501054803|22|"; content: "type="; content: "subtype="; classtype: suspicious-traffic; reference: url,wiki.quadrantsec.com/bin/view/Main/5000958; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000958; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] DNS - Domain Belongs to a Denied Category in Policy"; content: "logid=|22|1501054803|22|"; content: "type="; content: "subtype="; classtype: suspicious-traffic; reference: url,wiki.quadrantsec.com/bin/view/Main/5006100; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006100; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Web Filter Rating Error Occurred"; content: "logid=|22|0318012800|22|"; content: "type="; content: "subtype="; classtype: system-error; reference: url,wiki.quadrantsec.com/bin/view/Main/5000959; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000959; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Web Filter Rating Error Occurred"; content: "logid=|22|0318012800|22|"; content: "type="; content: "subtype="; classtype: system-error; reference: url,wiki.quadrantsec.com/bin/view/Main/5006101; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006101; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack Detected by UDP/TCP Anomaly"; content: "logid=|22|0720018432|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5000960; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000960; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack Detected by UDP/TCP Anomaly"; content: "logid=|22|0720018432|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5006102; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006102; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack Detected by ICMP Anomaly"; content: "logid=|22|0720018433|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5000961; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000961; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack Detected by ICMP Anomaly"; content: "logid=|22|0720018433|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5006103; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006103; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack Detected by Other Anomaly"; content: "logid=|22|0720018434|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5000962; parse_src_ip: 2; parse_dst_ip: 1; sid: 5000962; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Attack Detected by Other Anomaly"; content: "logid=|22|0720018434|22|"; content: "type="; content: "subtype="; classtype: misc-attack; reference: url,wiki.quadrantsec.com/bin/view/Main/5006104; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006104; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin Login Disabled"; content: "logid=|22|0100032021|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5000963; sid: 5000963; rev:3;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Admin Login Disabled"; content: "logid=|22|0100032021|22|"; content: "type="; content: "subtype="; classtype: system-event; reference: url,wiki.quadrantsec.com/bin/view/Main/5006105; sid: 5006105; rev:1;)
 


### PR DESCRIPTION
* fix for urls

* Typo

* Small update to systemd rules to threshold
Updated DisableScriptScanning to prevent FP's when Defender is configured from a master conf file

Added new ruless in Window Malware and Windows Powershell to detect Russian/Ukrainian conflict Wipers and Ransomeware. Also, for IOC's observed in recently observed Malware Samples.

Added Sysmon rule to detect windows interal API call to disable crash reports.

* Updated Systemd rules per JSuain

* Fixed a typos identified by new code!

* Added rule for Cisco Meraki WPA Authentication logs to normalize source MAC address

* GCP Cloud Audit rules

* Updated SIDs to remove duplicates

Co-authored-by: Champ Clark III <cclark@quadrantsec.com>
Co-authored-by: sdrenning <sdrenning@quadrantsec.com>
Co-authored-by: Charles <cgoggins@quadrantsec.com>