### PR TITLE
Modified Fortinet Rule to fix broken Hex

### DIFF
--- a/fortinet-648.rules
+++ b/fortinet-648.rules
@@ -80,7 +80,7 @@ alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Application contr
 
 alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Application control instant message chat message"; content: "logid=|22|1059028676|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5006064; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006064; rev:1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] VoIP-SIP session blocked"; content: "logid=|2|0814044033|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5006065; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006065; rev:1;)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] VoIP-SIP session blocked"; content: "logid=|22|0814044033|22|"; content: "type="; content: "subtype="; classtype: policy-violation; reference: url,wiki.quadrantsec.com/bin/view/Main/5006065; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006065; rev:2;)
 
 alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[FORTINET] Infected File Detected Within Email"; content: "logid=|22|0211008194|22|"; content: "type="; content: "subtype="; classtype: suspicious-traffic; reference: url,wiki.quadrantsec.com/bin/view/Main/5006066; parse_src_ip: 2; parse_dst_ip: 1; sid: 5006066; rev:1;)
 


### PR DESCRIPTION
Update to fix hex in fortinet-648 rules. Changed from |2| to |22|.