### PR TITLE
Update cisco-geoip.rules

### DIFF
--- a/cisco-geoip.rules
+++ b/cisco-geoip.rules
@@ -53,7 +53,7 @@ alert any $HOME_NET any -> $EXTERNAL_NET any (msg: "[CISCO-GEOIP] ACS Login succ
 
 # 2014-05-07 09:32:45|10.8.0.5|129815|local4|info|info|%ASA*-6-722022| Group <GroupPolicy1> User <Bob> IP <10.10.102.102> UDP SVC connection established without compression
 
-alert any $HOME_NET any -> $EXTERNAL_NET any (msg: "[CISCO-GEOIP] VPN login from outside HOME_COUNTRY [2]"; program: %ASA*-6-722022|%ASA*-6-722023; country_code: track by_src, isnot $HOME_COUNTRY; classtype: successful-user; parse_src_ip: 1; reference: url, wiki.quadrantsec.com/bin/view/Main/5002058; sid: 5002058; rev: 3;)
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg: "[CISCO-GEOIP] VPN login from outside HOME_COUNTRY [2]"; content:!"connection terminated"; program: %ASA*-6-722022|%ASA*-6-722023; country_code: track by_src, isnot $HOME_COUNTRY; classtype: successful-user; parse_src_ip: 1; reference: url, wiki.quadrantsec.com/bin/view/Main/5002058; sid: 5002058; rev: 3;)
 
 # 2014-05-07 16:41:47|192.168.1.1|7050594|local0|info|info|%ASA*-6-303002| FTP connection from inside:10.20.11.20/2351 to dmz:192.168.1.1/21, user bob Stored file somefile
 
@@ -63,3 +63,6 @@ alert any $HOME_NET any -> $EXTERNAL_NET any (msg: "[CISCO-GEOIP] FTP file trans
 # Track by dest
 alert any $HOME_NET any -> $EXTERNAL_NET any (msg: "[CISCO-GEOIP] FTP file transfer to outside HOME_COUNTRY"; program: %ASA*-6-303002; country_code: track by_dst, isnot $HOME_COUNTRY; default_proto: tcp; default_src_port: $HTTPS_PORT; classtype: successful-user; normalize; parse_src_ip: 1; parse_dst_ip: 2; reference: url, wiki.quadrantsec.com/bin/view/Main/5002060; sid: 5002060; rev: 6;)
 
+# 2014-05-07 09:32:45|10.8.0.5|129815|local4|info|info|%ASA*-6-722022| Group <GroupPolicy1> User <Bob> IP <10.10.102.102> TCP SVC connection terminated without compression
+
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg: "[CISCO-GEOIP] VPN connection termination from outside HOME_COUNTRY"; content:"connection terminated"; program: %ASA*-6-722022|%ASA*-6-722023; country_code: track by_src, isnot $HOME_COUNTRY; classtype: successful-user; parse_src_ip: 1; reference: url, wiki.quadrantsec.com/bin/view/Main/500641; sid: 5006541; rev: 3;)


### PR DESCRIPTION
Small tweak to Cisco GeoIP rules...

1: Added content not for "connection terminated" to SID 5002058, which was triggering false positives.
2: Created rule to trigger correctly on "TCP SVC connection terminated without compression" traffic. (The SID used here is within a range I have pre-ordained and documented for one-off additions, so no need to update SID file.)