### PR TITLE
Updated MSAPI-MCAS rules.

### DIFF
--- a/msapi-mcas.rules
+++ b/msapi-mcas.rules
@@ -26,19 +26,19 @@
 #*************************************************************
 #
 # Microsoft Cloud Application Security (MCAS) signatures. 
-# Initial Signature Set Written by by William Harding @ Quadrant Information Securit
+# Initial Signature Set Written by by William Harding @ Quadrant Information Security
 
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Activity from Infrequent Country"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_NEW_COUNTRY"; classtype: suspicious-traffic; sid: 5007203; rev: 1)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Activity from Infrequent Country"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_NEW_COUNTRY"; classtype: suspicious-traffic; sid: 5007203; rev: 1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Mass Delete"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_REPEATED_ACTIVITY_DELETE"; classtype: system-event; sid: 5007204; rev: 1)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Mass Delete"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_REPEATED_ACTIVITY_DELETE"; classtype: system-event; sid: 5007204; rev: 1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Repeated Failed Logins"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_REPEATED_ACTIVITY_FAILED_LOGIN"; classtype: brute-force; sid: 5007205; rev: 1)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Repeated Failed Logins"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_REPEATED_ACTIVITY_FAILED_LOGIN"; classtype: brute-force; sid: 5007205; rev: 1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Activity from an Anonymous Proxy"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_RISKY_IP_ANONYMOUS"; classtype: suspicious-traffic; sid: 5007206; rev: 1)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Activity from an Anonymous Proxy"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_RISKY_IP_ANONYMOUS"; classtype: suspicious-traffic; sid: 5007206; rev: 1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Impossible Travel Activity"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_VELOCITY"; classtype: suspicious-traffic; sid: 5007207; rev: 1)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Impossible Travel Activity"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_VELOCITY"; classtype: suspicious-traffic; sid: 5007207; rev: 1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Suspicious Inbox Manipulation Rule"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_INBOX_HIDING"; classtype: configuration-change; sid: 5007208; rev: 1)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Suspicious Inbox Manipulation Rule"; program: MCAS; json_content: ".Operation", "MCAS_ALERT_ANUBIS_DETECTION_INBOX_HIDING"; classtype: configuration-change; sid: 5007208; rev: 1;)
 
-alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Possible Unknown MCAS Alert"; program: MCAS; json_content: ".Operation", "MCAS_ALERT"; json_contains; classtype: bad-unknown; sid: 5007209; rev: 1)
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg: "[MCAS] Possible Unknown MCAS Alert"; program: MCAS; json_content: ".Operation", "MCAS_ALERT"; json_contains; classtype: bad-unknown; sid: 5007209; rev: 1;)


### PR DESCRIPTION
Added missing semicolon; missing y.

I am unsure how Sagan was able to read these rules in without the missing `;`.