### PR TITLE
remove duplicate dynamic rules file entry

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -229,7 +229,6 @@ rules-files:
   - $RULE_PATH/digitalpersona.rules
   - $RULE_PATH/dovecot.rules
   - $RULE_PATH/duo.rules
-  - $RULE_PATH/dynamic.rules
   - $RULE_PATH/f5-big-ip.rules
   - $RULE_PATH/fatpipe.rules
   - $RULE_PATH/fingerprint.rules


### PR DESCRIPTION
dynamic.rules is listed twice.