### PR TITLE
Correcting normalization rule syntax

### DIFF
--- a/normalization.rulebase
+++ b/normalization.rulebase
@@ -37,7 +37,7 @@ prefix=
 # arpalert
 # seq=277, mac=00:01:d7:35:55:06, ip=172.22.1.53, reference=172.22.2.69, type=ip_change, dev=eth0, vendor="F5 Networks, Inc."
 
-rule=:seq=%-:word%, mac=%-:word%, ip=%src-ip:ipv4%, reference=%dst-ip:ipv4%, %-:rest%
+rule=: seq=%-:word%, mac=%-:word%, ip=%src-ip:ipv4%, reference=%dst-ip:ipv4%, %-:rest%
 
 #*****************************************************************************
 # Bro
@@ -45,7 +45,7 @@ rule=:seq=%-:word%, mac=%-:word%, ip=%src-ip:ipv4%, reference=%dst-ip:ipv4%, %-:
 
 # This is a "custom" bro output Sagan uses for file hashes from Bro.
 
-rule=:files: %-:word% %-:word% %src-ip:ipv4% %dst-ip:ipv4% %-:word% %-:word% %-:number% %-:word% %mime-type:word% %-:word% %-:word% %-:word% %-:word% %-:number% %-:number% %-:number% %-:number% %-:word% %-:word% %filehash-md5:word% %filehash-sha1:word% %filehash-sha256:word% %-:rest%
+rule=: files: %-:word% %-:word% %src-ip:ipv4% %dst-ip:ipv4% %-:word% %-:word% %-:number% %-:word% %mime-type:word% %-:word% %-:word% %-:word% %-:word% %-:number% %-:number% %-:number% %-:number% %-:word% %-:word% %filehash-md5:word% %filehash-sha1:word% %filehash-sha256:word% %-:rest%
 
 #*****************************************************************************
 # Cisco
@@ -53,56 +53,56 @@ rule=:files: %-:word% %-:word% %src-ip:ipv4% %dst-ip:ipv4% %-:word% %-:word% %-:
 
 #  1w3d: %SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host 192.168.0.1
 
-rule=:%uptime:word% %authfail:word% Authentication failure for SNMP req from host %src-ip:ipv4%
+rule=: %uptime:word% %authfail:word% Authentication failure for SNMP req from host %src-ip:ipv4%
 
 #  Dec 26 19:59:26: %SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host 10.1.128.27
 
-rule=:%month:word% %day:word% %hour:word% %%SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host %src-ip:ipv4%
+rule=: %month:word% %day:word% %hour:word% %%SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host %src-ip:ipv4%
 
 # Access denied URL http://www.example.com/somethings.txt SRC 192.168.0.1 DEST 10.10.10.10 on interface inside
 
-rule=:Access denied URL %url:word% SRC %src-ip:ipv4% DEST %dst-ip:ipv4% %-:rest%
+rule=: Access denied URL %url:word% SRC %src-ip:ipv4% DEST %dst-ip:ipv4% %-:rest%
 
 # Caused by WebVPN or IPSec
 # AAA user authentication Successful : server =  10.10.10.10 : user = domain\bob
 
-rule=:AAA user authentication Successful : server =  %ip-src:ipv4% : user = %username:word%
-rule=:AAA user authentication Rejected : reason = AAA failure : server = %src-ip:ipv4% : user = %username:word%
+rule=: AAA user authentication Successful : server =  %ip-src:ipv4% : user = %username:word%
+rule=: AAA user authentication Rejected : reason = AAA failure : server = %src-ip:ipv4% : user = %username:word%
 
 # User authentication failed: Uname: timothy
 
-rule=:User authentication failed: Uname: %username:word%
+rule=: User authentication failed: Uname: %username:word%
 
 # Space at the end of this line!
 # %ASA-6-315011: SSH session from 192.168.0.1  on interface Outside2 for user "test" disconnected by SSH server, reason: "Internal error" (0x00)
 #                SSH session from 10.20.10.200 on interface Outside2 for user "root" disconnected by SSH server, reason: "Internal error" (0x00)
 
-rule=:SSH session from %src-ip:ipv4% on interface %-:word% for user %username:quoted-string% disconnected by SSH server, %-:rest%
-rule=:SSH session from %src-ip:ipv4%  on interface %-:word% for user %username:quoted-string% disconnected by SSH server, %-:rest%
+rule=: SSH session from %src-ip:ipv4% on interface %-:word% for user %username:quoted-string% disconnected by SSH server, %-:rest%
+rule=: SSH session from %src-ip:ipv4%  on interface %-:word% for user %username:quoted-string% disconnected by SSH server, %-:rest%
 
-rule=:Configured from console by %-:word% (%src-ip:ipv4%)
-rule=:Authentication failure for %proto:word% req from host %src-ip:ipv4%
-rule=:Attempted to connect to %username:word% from %src-ip:ipv4%
+rule=: Configured from console by %-:word% (%src-ip:ipv4%)
+rule=: Authentication failure for %proto:word% req from host %src-ip:ipv4%
+rule=: Attempted to connect to %username:word% from %src-ip:ipv4%
 
 # 02:19:47.007 UTC: %SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host 10.10.10.10
 #
-rule=:%-:word% %-:word% %-:word% %-:word% %%SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host %src-ip:ipv4%
+rule=: %-:word% %-:word% %-:word% %-:word% %%SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host %src-ip:ipv4%
 
 # Deny TCP (no connection) from perforce/139 to 192.168.73.1/2048 flags RST ACK  on interface INSIDE
 #
-rule=:Deny %proto:word% (no connection) from %src-ip:ipv4%/%src-port:number% to %dst-ip:ipv4%/%dst-port:number% flags %-:rest%
+rule=: Deny %proto:word% (no connection) from %src-ip:ipv4%/%src-port:number% to %dst-ip:ipv4%/%dst-port:number% flags %-:rest%
 
 # Mar 31 02:30:42.815 UTC: %SYS-5-CONFIG_I: Configured from console by sachen on vty0 (10.32.23.63)
 #
-rule=:%-:word% %-:word% %-:word% %-:word% %%SYS-5-CONFIG_I: Configured from console by %username:word% on %-:word% (%src-ip:ipv4%)
+rule=: %-:word% %-:word% %-:word% %-:word% %%SYS-5-CONFIG_I: Configured from console by %username:word% on %-:word% (%src-ip:ipv4%)
 
 # Deny inbound UDP from 46.161.166.49/63905 to 214.20.10.211/65257 on interface OUTSIDE
 #
-rule=:Deny inbound UDP from %src-ip:ipv4%/%src-port:number% to %dst-ip:ipv4%/%dst-port:number% %-:rest%
+rule=: Deny inbound UDP from %src-ip:ipv4%/%src-port:number% to %dst-ip:ipv4%/%dst-port:number% %-:rest%
 
 # Denied ICMP type=8, code=0 from 159.101.118.111 on interface INSIDE
 #
-rule=:Denied ICMP type=%-:number%, code=%-:number% from %src-ip:ipv4% %-:rest%
+rule=: Denied ICMP type=%-:number%, code=%-:number% from %src-ip:ipv4% %-:rest%
 
 # These cover a lot of WebVPN, etc rules.
 #
@@ -111,37 +111,37 @@ rule=:Denied ICMP type=%-:number%, code=%-:number% from %src-ip:ipv4% %-:rest%
 # Group <Mobile VPN Group Policy> User <Bob> IP <10.10.10.10> SVC closing connection: Transport closing.
 # Group <Mobile VPN Group Policy> User <BobR> IP <10.10.10.10> SVC Message: 17/ERROR: Reconnecting to recover from error..
 #
-rule=:Group <%-:char-to:\x3e%> User <%username:char-to:\x3e%> IP <%src-ip:char-to:\x3e%> %-:rest%
+rule=: Group <%-:char-to:\x3e%> User <%username:char-to:\x3e%> IP <%src-ip:char-to:\x3e%> %-:rest%
 
 # Teardown UDP connection 31929471 for inside:10.10.10.10/1111 to dmz:239.254.0.4/12224 duration 0:00:00 bytes 0
 # Teardown TCP connection 1829067148 for outside:10.10.10.10/443 to inside:192.168.1.1/10830 duration 0:03:04 bytes 8699 TCP FINs"
 
-rule=:Teardown %proto:word% connection %connection:number% for %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number% %-:rest%
+rule=: Teardown %proto:word% connection %connection:number% for %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number% %-:rest%
 
 # Teardown ICMP connection for faddr 10.10.10.10/0 gaddr 192.168.1.1/10000 laddr 192.168.1.1/100001
 
-rule=:Teardown %proto:word% connection for %-:word% %src-ip:ipv4%/%src-port:number% %-:word% %dst-ip:ipv4%/28694 %-:rest%
+rule=: Teardown %proto:word% connection for %-:word% %src-ip:ipv4%/%src-port:number% %-:word% %dst-ip:ipv4%/28694 %-:rest%
 
 # access-list inside_egress permitted tcp inside/10.10.10.1(10000) -> outside/192.186.1.1(80) hit-cnt 1 first hit [0xf83f456b, 0x0]
 
-rule=:access-list %-:word% permitted %proto:word% %-:char-to:\x2f%/%src-ip:ipv4%(%src-port:number%) -> %-:char-to:\x2f%/%dst-ip:ipv4%(%dst-port:number%) %-:rest%
+rule=: access-list %-:word% permitted %proto:word% %-:char-to:\x2f%/%src-ip:ipv4%(%src-port:number%) -> %-:char-to:\x2f%/%dst-ip:ipv4%(%dst-port:number%) %-:rest%
 
 # Built inbound TCP connection 3171137 for outside:10.10.10.10/10000 (10.10.10.10/10000)(DOMAIN\Bob) to inside:192.168.1.10/80 (192.168.1.1/80) (Bob)
 
-rule=:Built %-:word% %proto:word% connection %-:number% for %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% (%-:ipv4%/58521)(%domain:char-to:\x5c%\%username:char-to:\x29%) to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number% %-:rest%
+rule=: Built %-:word% %proto:word% connection %-:number% for %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% (%-:ipv4%/58521)(%domain:char-to:\x5c%\%username:char-to:\x29%) to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number% %-:rest%
 
 # Built inbound TCP connection 1834111354 for outside:10.10.10.10/28490 (10.10.10.10/28490) to dmz:192.168.1.1/80 (192.168.1.1/80)
 
-rule=:Built %-:word% %proto:word% connection %-:number% for %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% %-:word% to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number% %-:rest%
+rule=: Built %-:word% %proto:word% connection %-:number% for %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% %-:word% to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number% %-:rest%
 
 #  Group = Employee, Username = bob, IP = 10.10.10.10, Error processing payload: Payload ID: 14
 
-rule=:Group = %-:word%, Username = %username:word%, IP = %src-ip:ipv4%, %-:rest%
-rule=:Group = %-:char-to:\x2c%, Username = %username:char-to:\x2c%, IP = %src-ip:ipv4%, %-:rest%
+rule=: Group = %-:word%, Username = %username:word%, IP = %src-ip:ipv4%, %-:rest%
+rule=: Group = %-:char-to:\x2c%, Username = %username:char-to:\x2c%, IP = %src-ip:ipv4%, %-:rest%
 
 # FTP connection from inside:10.10.1.1/3789 to outside:12.12.12.12/21, user bob Retrieved file somefile.txt
 
-rule=:FTP connection from %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number%, user %username:word% %-:rest%
+rule=: FTP connection from %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number%, user %username:word% %-:rest%
 
 # TCP access denied by ACL from 10.10.10.10/28490 to inside:192.168.1.1/80
 
@@ -149,31 +149,31 @@ rule =: TCP access denied by ACL from %src-ip:ipv4%/%src-port:number% to %-:char
 
 # Teardown TCP connection 361112504 for outside:10.10.1.100/61160(LOCAL\Bob) to inside:12.159.2.124/443 duration 0:00:13 bytes 3216 TCP FINs (Bob)
 
-rule=:Teardown %proto:word% connection %-:number% for outside:%src-ip:ipv4%/%src-port:number%%-:word% to inside:%dst-ip:ipv4%/%dst-port:number% %-:rest%
+rule=: Teardown %proto:word% connection %-:number% for outside:%src-ip:ipv4%/%src-port:number%%-:word% to inside:%dst-ip:ipv4%/%dst-port:number% %-:rest%
 
 # Cisco ACS normalization
 
-rule=:%-:word% %-:number% %-:number% %-:word% %-:word% %-:word% %-:word% %-:word% NOTICE Failed-Attempt: Authentication failed, ACSVersion=%-:word% ConfigVersionId=%-:word% Device IP Address=%src-ip:char-to:\x2c%, Device Port=%src-port:char-to:\x2c%, UserName=%username:char-to:\x2c%, Protocol=%-:word% RequestLatency=%-:word% NetworkDeviceName=%-:word% Type=Authentication, Action=Login, Privilege-Level=%-:word% Authen-Type=%-:word% Service=Login, User=%-:word% Port=%-:word% Remote-Address=%dst-ip:char-to:\x2c%, %-:rest%
+rule=: %-:word% %-:number% %-:number% %-:word% %-:word% %-:word% %-:word% %-:word% NOTICE Failed-Attempt: Authentication failed, ACSVersion=%-:word% ConfigVersionId=%-:word% Device IP Address=%src-ip:char-to:\x2c%, Device Port=%src-port:char-to:\x2c%, UserName=%username:char-to:\x2c%, Protocol=%-:word% RequestLatency=%-:word% NetworkDeviceName=%-:word% Type=Authentication, Action=Login, Privilege-Level=%-:word% Authen-Type=%-:word% Service=Login, User=%-:word% Port=%-:word% Remote-Address=%dst-ip:char-to:\x2c%, %-:rest%
 
 #Cisco meraki normalization
 #1690812638.429532373 STE215_Breakroom events type=8021x_eap_failure radio='1' vap='0' client_mac='B8:8A:60:79:FD:65' identity='host/WS-4497.sbmgroup.local' aid='1020865390'
-rule=:%-:number%.%-:number% %-:word% events type=%-:word% radio='%-:number%' vap='%-:number%' client_mac='%string:mac48%' %-:rest%
+rule=: %-:number%.%-:number% %-:word% events type=%-:word% radio='%-:number%' vap='%-:number%' client_mac='%string:mac48%' %-:rest%
 
 #1609348633.422414486 AP_1_05 events type=disassociation radio='0' vap='1' client_mac='B8:31:B5:89:9A:6A'
-rule=:%-:number%.%-:number% %-:alpha%_%-:number%_%-:number% events type=%-:word% radio='%-:number%' vap='%-:number%' client_mac='%srcmac:mac48%' %-:rest%
+rule=: %-:number%.%-:number% %-:alpha%_%-:number%_%-:number% events type=%-:word% radio='%-:number%' vap='%-:number%' client_mac='%srcmac:mac48%' %-:rest%
 
 ##1609440458.095981119 Temp_IDF_AP events type=disassociation radio='0' vap='1' client_mac='74:70:FD:7C:60:55'
-rule=:%-:number%.%-:number% %-:alpha%_%-:alpha%_%-:alpha% events type=%-:word% radio='%-:number%' vap='%-:number%' client_mac='%srcmac:mac48%%-:rest%'
+rule=: %-:number%.%-:number% %-:alpha%_%-:alpha%_%-:alpha% events type=%-:word% radio='%-:number%' vap='%-:number%' client_mac='%srcmac:mac48%%-:rest%'
 
 
 #*****************************************************************************
 # DNS (bind, etc)
 #*****************************************************************************
 
-rule=:client %src-ip:ipv4%#%src-port:number%: update '%-:char-to:\x27%' denied
-rule=:client %src-ip:ipv4%#%src-port:number%: query (cache) '%-:char-to:\x27%' denied
-rule=:unexpected RCODE %-:word% resolving '%-:char-to:\x27%': %src-ip:ipv4%#%src-port:number%
-rule=:error (unexpected RCODE %-:word% resolving '%-:char-to:\x27%': %src-ip:ipv4%#%src-port:number%
+rule=: client %src-ip:ipv4%#%src-port:number%: update '%-:char-to:\x27%' denied
+rule=: client %src-ip:ipv4%#%src-port:number%: query (cache) '%-:char-to:\x27%' denied
+rule=: unexpected RCODE %-:word% resolving '%-:char-to:\x27%': %src-ip:ipv4%#%src-port:number%
+rule=: error (unexpected RCODE %-:word% resolving '%-:char-to:\x27%': %src-ip:ipv4%#%src-port:number%
 
 #*****************************************************************************
 # Fortinet/Fortigate
@@ -181,26 +181,26 @@ rule=:error (unexpected RCODE %-:word% resolving '%-:char-to:\x27%': %src-ip:ipv
 
 #Fortinet VPN
 #date=2025-03-24 time=23:42:24 devname="XXdevnameXX" devid="FGT80FTK21001925" eventtime=1742881344950883870 tz="-0600" logid="0101039426" type="event" subtype="vpn" level="alert" vd="root" logdesc="SSL VPN login fail" action="ssl-login-fail" tunneltype="ssl-web" tunnelid=0 remip=198.44.136.74 user="canon" group="N/A" dst_host="N/A" reason="sslvpn_login_permission_denied" msg="SSL user failed to logged in"
-rule=:date=%-:word% time=%-:word% devname=%-:word% devid=%-:word% eventtime=%-:number% tz=%-:word% logid=%-:word% type=%-:word% subtype=%-:word% level=%-:word% vd=%-:word% logdesc="%-:char-to:\x22%" action=%-:word% tunneltype=%-:word% tunnelid=%-:number% remip=%src-ip:ipv4% user="%username:char-to:\x22%" %-:rest%
+rule=: date=%-:word% time=%-:word% devname=%-:word% devid=%-:word% eventtime=%-:number% tz=%-:word% logid=%-:word% type=%-:word% subtype=%-:word% level=%-:word% vd=%-:word% logdesc="%-:char-to:\x22%" action=%-:word% tunneltype=%-:word% tunnelid=%-:number% remip=%src-ip:ipv4% user="%username:char-to:\x22%" %-:rest%
 
-rule=:time=%-:word% devname=%-:word% devid=%-:word% logid=%-:word% type=%-:word% subtype=%-:word% level=%-:word% vd=%-:word% srcip=%src-ip:ipv4% srcport=%src-port:number% srcintf=%-:word% dstip=%dst-ip:ipv4% dstport=%dst-port:number% dstintf=%-:word% %-:rest%
+rule=: time=%-:word% devname=%-:word% devid=%-:word% logid=%-:word% type=%-:word% subtype=%-:word% level=%-:word% vd=%-:word% srcip=%src-ip:ipv4% srcport=%src-port:number% srcintf=%-:word% dstip=%dst-ip:ipv4% dstport=%dst-port:number% dstintf=%-:word% %-:rest%
 
-rule=:%-:string-to:user=%user="%username:char-to:\x22%%-:rest%
+rule=: %-:string-to:user=%user="%username:char-to:\x22%%-:rest%
 
 #*****************************************************************************
 # IMAP
 #*****************************************************************************
 
-rule=:Logout user=%username:word% host=%-:word% [%src-ip:ipv4%]
-rule=:Login excessive login failures user=%username:word% auth=%-:word% host=%-:word% [%src-ip:ipv4%]
-rule=:Login failed user=%username:word% auth=%-:word% host=%-:word% [%src-ip:ipv4%]
-rule=:authentication failure; logname= uid=%-:word% euid=%-:word% tty=%-:word% ruser=%-:word% rhost=%src-ip:ipv4% user=%username:word%
+rule=: Logout user=%username:word% host=%-:word% [%src-ip:ipv4%]
+rule=: Login excessive login failures user=%username:word% auth=%-:word% host=%-:word% [%src-ip:ipv4%]
+rule=: Login failed user=%username:word% auth=%-:word% host=%-:word% [%src-ip:ipv4%]
+rule=: authentication failure; logname= uid=%-:word% euid=%-:word% tty=%-:word% ruser=%-:word% rhost=%src-ip:ipv4% user=%username:word%
 
 #*****************************************************************************
 # Imperva
 #*****************************************************************************
 
-rule=:act=Block dst=%dst-ip:ipv4% dpt=%src-port:number% duser=%username:word% src=%src-ip:ipv4% spt=%src-port:number% proto=%proto:word% %all:rest%
+rule=: act=Block dst=%dst-ip:ipv4% dpt=%src-port:number% duser=%username:word% src=%src-ip:ipv4% spt=%src-port:number% proto=%proto:word% %all:rest%
 
 #*****************************************************************************
 # Linux kernel
@@ -213,7 +213,7 @@ rule=:act=Block dst=%dst-ip:ipv4% dpt=%src-port:number% duser=%username:word% sr
 #
 # [6251572.861709] IN=fire OUT=fire PHYSIN=eth0 PHYSOUT=eth1 SRC=X.X.X.X DST=X.X.X.X LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=9133 DF PROTO=TCP SPT=50661 DPT=113 WINDOW=5840 RES=0x00 SYN URGP=0
 
-rule=:%-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% PHYSOUT=%-:word% SRC=%src-ip:ipv4% DST=%dst-ip:ipv4% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:number% ID=%-:number% %-:word% PROTO=%proto:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
+rule=: %-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% PHYSOUT=%-:word% SRC=%src-ip:ipv4% DST=%dst-ip:ipv4% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:number% ID=%-:number% %-:word% PROTO=%proto:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
 
 # iptables UDP : iptables flags "--state NEW,INVALID -j LOG"  (NOTE: no --prefix!)
 #
@@ -221,9 +221,9 @@ rule=:%-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% PHYSOUT=%-:word% SRC=%sr
 # [6255730.106539] IN=fire OUT=fire PHYSIN=eth0 SRC=X.X.X.X DST=X.X.X.X LEN=76 TOS=0x00 PREC=0xC0 TTL=63 ID=34162 PROTO=UDP SPT=123 DPT=123 LEN=56
 # [6256275.991117] IN=fire OUT=fire PHYSIN=eth0 PHYSOUT=eth1 SRC=X.X.X.X DST=X.X.X.X LEN=241 TOS=0x00 PREC=0x00 TTL=64 ID=0 DF PROTO=UDP SPT=138 DPT=138 LEN=221
 
-rule=:%-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% PHYSOUT=%-:word% SRC=%src-ip:ipv4% DST=%dst-ip:ipv4% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:word% ID=%-:number% PROTO=%-:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
+rule=: %-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% PHYSOUT=%-:word% SRC=%src-ip:ipv4% DST=%dst-ip:ipv4% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:word% ID=%-:number% PROTO=%-:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
 
-rule=:%-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% SRC=%src-ip:ipv4% DST=%dst-ip:ipv4% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:number% ID=%-:number% PROTO=%proto:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
+rule=: %-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% SRC=%src-ip:ipv4% DST=%dst-ip:ipv4% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:number% ID=%-:number% PROTO=%proto:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
 
 #*****************************************************************************
 # nfcap / nfdump
@@ -231,48 +231,48 @@ rule=:%-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% SRC=%src-ip:ipv4% DST=%d
 
 # source_ip: 10.1.1.1/54630, destination_ip: 12.159.2.100/13620, protocol: TCP, duration: 0.204, flags: |.A..S.|, tos: 0, packets: 2, bytes: 92, last_time: 2015-06-04 18:29:58, reported by 10.5.1.1
 
-rule=:source_ip: %src-ip:ipv4%/%src-port:number%, destination_ip: %dst-ip:ipv4%/%dst-port:number%, protocol: %proto:char-to:\x2c%, %-:rest%
+rule=: source_ip: %src-ip:ipv4%/%src-port:number%, destination_ip: %dst-ip:ipv4%/%dst-port:number%, protocol: %proto:char-to:\x2c%, %-:rest%
 
 #*****************************************************************************
 # OpenSSH
 #*****************************************************************************
 
-rule=:Failed %-:word% for invalid user %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=:Accepted %-:word% for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=:Accepted keyboard-interactive/pam for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=:Accepted password for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=:error: PAM: Authentication failure for %username:word% from %src-ip:ipv4%
-rule=:error: PAM: Authentication failure for %username:word% from %src-host:word%
-rule=:pam_unix(sshd:auth): authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:ipv4%  user=%username:word%
-rule=:pam_unix(sshd:auth): authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:ipv4%
-rule=:PAM %number:number% more authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:ipv4%
-rule=:Accepted publickey for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=:error: PAM: Authentication failure for illegal user %username:word% from %src-ip:ipv4%
-rule=:Failed password for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=:Accepted gssapi-with-mic for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=:Postponed keyboard-interactive for invalid user %username:word% from %src-ip:ipv4% port %src-port:number% ssh2 [preauth]
-rule=:Failed keyboard-interactive/pam for invalid user %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=:input_userauth_request: invalid user %username:word% [preauth]
-rule=:Invalid user %username:word% from %src-ip:ipv4%
-rule=:Invalid user %username:word% from %src-ip:ipv4% port %src-port:number%
-rule=:Disconnecting: Too many authentication failures for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2 %-:rest%
-rule=:Disconnected from invalid user %username:word% %src-ip:ipv4% port %src-port:number% %-:rest%
-rule=:Did not receive identification string from %src-ip:ipv6% port %src-port:number%
-rule=:pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=%src-host:word%
-rule=:Did not receive identification string from %src-p:ipv4%
-rule=:Did not receive identification string from %src-ip:ipv6%
-rule=:Bad protocol version identification '%-:char-to:\x27%' from %src-ip:ipv4% port %src-port:number%
-rule=:Bad protocol version identification '%-:char-to:\x27%' from %src-ip:ipv6% port %src-port:number%
-rule=:Bad protocol version identification '' from %src-ip:ipv4% port %src-port:number%
-rule=:Bad protocol version identification '' from %src-ip:ipv6% port %src-port:number%
-#rule=:password check failed for user (%src-ip:char-to:\x29%)
-rule=:User %username:word% from %src-ip:ipv4% not allowed %-:rest%
-rule=:User %username:word% from %src-ip:ipv6% not allowed %-:rest%
+rule=: Failed %-:word% for invalid user %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
+rule=: Accepted %-:word% for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
+rule=: Accepted keyboard-interactive/pam for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
+rule=: Accepted password for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
+rule=: error: PAM: Authentication failure for %username:word% from %src-ip:ipv4%
+rule=: error: PAM: Authentication failure for %username:word% from %src-host:word%
+rule=: pam_unix(sshd:auth): authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:ipv4%  user=%username:word%
+rule=: pam_unix(sshd:auth): authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:ipv4%
+rule=: PAM %number:number% more authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:ipv4%
+rule=: Accepted publickey for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
+rule=: error: PAM: Authentication failure for illegal user %username:word% from %src-ip:ipv4%
+rule=: Failed password for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
+rule=: Accepted gssapi-with-mic for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
+rule=: Postponed keyboard-interactive for invalid user %username:word% from %src-ip:ipv4% port %src-port:number% ssh2 [preauth]
+rule=: Failed keyboard-interactive/pam for invalid user %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
+rule=: input_userauth_request: invalid user %username:word% [preauth]
+rule=: Invalid user %username:word% from %src-ip:ipv4%
+rule=: Invalid user %username:word% from %src-ip:ipv4% port %src-port:number%
+rule=: Disconnecting: Too many authentication failures for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2 %-:rest%
+rule=: Disconnected from invalid user %username:word% %src-ip:ipv4% port %src-port:number% %-:rest%
+rule=: Did not receive identification string from %src-ip:ipv6% port %src-port:number%
+rule=: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=%src-host:word%
+rule=: Did not receive identification string from %src-p:ipv4%
+rule=: Did not receive identification string from %src-ip:ipv6%
+rule=: Bad protocol version identification '%-:char-to:\x27%' from %src-ip:ipv4% port %src-port:number%
+rule=: Bad protocol version identification '%-:char-to:\x27%' from %src-ip:ipv6% port %src-port:number%
+rule=: Bad protocol version identification '' from %src-ip:ipv4% port %src-port:number%
+rule=: Bad protocol version identification '' from %src-ip:ipv6% port %src-port:number%
+#rule=: password check failed for user (%src-ip:char-to:\x29%)
+rule=: User %username:word% from %src-ip:ipv4% not allowed %-:rest%
+rule=: User %username:word% from %src-ip:ipv6% not allowed %-:rest%
 
 #*****************************************************************************
 # Yubikey
 #*****************************************************************************
-rule=:password check failed for user (%username:char-to:\x29%)
+rule=: password check failed for user (%username:char-to:\x29%)
 
 #*****************************************************************************
 # Palo-Alto
@@ -323,7 +323,7 @@ rule=traffic,pattern2:TRAFFIC,%subtype:char-sep:\x2C%,%dtm:char-sep:\x2C%,%genye
 rule=traffic,pattern33:TRAFFIC,%subtype:char-sep:\x2C%,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%bytes:number%,%bytes_sent:number%,%bytes_received:number%,%packets:number%,%start_time:char-sep:\x2C%,%elapsed_time:number%,%url_category:char-sep:\x2C%,%-:char-sep:\x2C%,%sequence_number:number%,%panorama_flags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%-:char-sep:\x2C%,%packets_sent:number%,%packets_received:number%,%therest:rest%
 
 rule=traffic,pattern44:TRAFFIC,%subtype:char-sep:\x2C%,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%bytes:number%,%bytes_sent:number%,%bytes_received:number%,%packets:number%,%start_time:char-sep:\x2C%,%elapsed_time:number%,%url_category:char-sep:\x2C%,%-:char-sep:\x2C%,%sequence_number:number%,%panorama_flags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%-:char-sep:\x2C%,%packets_sent:number%,%packets_received:number%
-rule=:%time:time-24hr%,%devserial:char-sep:\x2C%,url-log,pattern4:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:char-sep:\x2C%,(9999),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=: %time:time-24hr%,%devserial:char-sep:\x2C%,url-log,pattern4:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:char-sep:\x2C%,(9999),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
 #******************
 #SET EMPTY PREFIX
@@ -340,15 +340,15 @@ rule=: port %-:number% - Security Violation
 # SMTP
 #*****************************************************************************
 
-rule=:%-:word% %-:word% [%src-ip:ipv4%]: expn %username:word%
+rule=: %-:word% %-:word% [%src-ip:ipv4%]: expn %username:word%
 
 # p0IGs29E022795: ruleset=check_rcpt, arg1=<bob@example.com>, relay=mailhost.example.com [192.168.0.1], reject=553 5.1.8 <frank@example.com>... Domain of sender address bogus@example.com does not exist
 
-rule=:%-:word% ruleset=check_rcpt, %-:word% relay=%y:word% [%src-ip:ipv4%] (may be forged), reject=%-:number% %-:rest%
+rule=: %-:word% ruleset=check_rcpt, %-:word% relay=%y:word% [%src-ip:ipv4%] (may be forged), reject=%-:number% %-:rest%
 
 # p0I3FCpA013475: [192.168.0.1]: Possible SMTP RCPT flood, throttling.
 
-rule=:%-:word%: [%src-ip:ipv4%]: Possible SMTP RCPT flood, throttling.
+rule=: %-:word%: [%src-ip:ipv4%]: Possible SMTP RCPT flood, throttling.
 
 #*****************************************************************************
 # Snort
@@ -357,11 +357,11 @@ rule=:%-:word%: [%src-ip:ipv4%]: Possible SMTP RCPT flood, throttling.
 # Jun  2 00:41:47 demo snort: [1:19559:5] INDICATOR-SCAN SSH brute force login attempt [Classification: Misc activity] [Priority: 3] {TCP} 43.255.188.148:35236 -> 10.5.1.3:22
 
 
-rule=:[%generator_id:number%:%sig_id:number%:%rev:number%] %sig_name:char-to:\x5b%[Classification: %classtype:char-to:\x5d%] [Priority: %pri:number%] {%proto:char-to:\x7d%} %src-ip:ipv4%:%src-port:number% -> %dst-ip:ipv4%:%dst-port:number%
+rule=: [%generator_id:number%:%sig_id:number%:%rev:number%] %sig_name:char-to:\x5b%[Classification: %classtype:char-to:\x5d%] [Priority: %pri:number%] {%proto:char-to:\x7d%} %src-ip:ipv4%:%src-port:number% -> %dst-ip:ipv4%:%dst-port:number%
 
 # Appears the later version of Snort add a : after the "Priority" field.
 
-rule=:[%generator_id:number%:%sig_id:number%:%rev:number%] %sig_name:char-to:\x5b%[Classification: %classtype:char-to:\x5d%] [Priority: %pri:number%]: {%proto:char-to:\x7d%} %src-ip:ipv4%:%src-port:number% -> %dst-ip:ipv4%:%dst-port:number%
+rule=: [%generator_id:number%:%sig_id:number%:%rev:number%] %sig_name:char-to:\x5b%[Classification: %classtype:char-to:\x5d%] [Priority: %pri:number%]: {%proto:char-to:\x7d%} %src-ip:ipv4%:%src-port:number% -> %dst-ip:ipv4%:%dst-port:number%
 
 
 #*****************************************************************************
@@ -370,96 +370,96 @@ rule=:[%generator_id:number%:%sig_id:number%:%rev:number%] %sig_name:char-to:\x5
 
 # Remember the space at the end of the rule..  Also " counts as part of a %thing:word%
 
-rule=:id=%firewall:word% sn=%serial:word% time="%date:date-iso% %time:time-24hr%" fw=%fire-ip:ipv4% pri=%pri:number% c=%c:number% m=%m:number% msg="Possible port scan detected" n=%n:number% src=%src-ip:ipv4%:%src-port:number%:%interface:word% dst=%dst-ip:ipv4%:%dst-port:number%:%interface:word% note=%ports-scanned:quoted-string%
+rule=: id=%firewall:word% sn=%serial:word% time="%date:date-iso% %time:time-24hr%" fw=%fire-ip:ipv4% pri=%pri:number% c=%c:number% m=%m:number% msg="Possible port scan detected" n=%n:number% src=%src-ip:ipv4%:%src-port:number%:%interface:word% dst=%dst-ip:ipv4%:%dst-port:number%:%interface:word% note=%ports-scanned:quoted-string%
 
 #rule=: msg="%alert:char-to:\x22%" sid=%sid:number% ipscat=%proto:word% ipspri=%ipspri:number% n=%n:number% src=%src-ip:ipv4%:%src-port:number%:%interface:word% dst=%dst-ip:ipv4%:%dst-port:number%:%interface:word%
 
-rule=:id=%firewall:word% sn=%serial:word% time="%date:date-iso% %time:time-24hr%" fw=%fire-ip:ipv4% pri=%pri:number% c=%c:number% m=%m:number% msg=%alert:quoted-string% sid=%sid:number% ipscat=%proto:word% ipspri=%ipspri:number% n=%n:number% src=%src-ip:ipv4%:%src-port:number%:%interface:word% dst=%dst-ip:ipv4%:%dst-port:number%:%interface:word%
+rule=: id=%firewall:word% sn=%serial:word% time="%date:date-iso% %time:time-24hr%" fw=%fire-ip:ipv4% pri=%pri:number% c=%c:number% m=%m:number% msg=%alert:quoted-string% sid=%sid:number% ipscat=%proto:word% ipspri=%ipspri:number% n=%n:number% src=%src-ip:ipv4%:%src-port:number%:%interface:word% dst=%dst-ip:ipv4%:%dst-port:number%:%interface:word%
 
 #*****************************************************************************
 # su/sudo
 #*****************************************************************************
 
-rule=:Successful su for %-:word% by %username:word%
-rule=:pam_unix(sudo:auth): authentication failure; logname= uid=%uid:number% euid=%-:number% %-:word% ruser= rhost=  user=%username:word%
-rule=:%username:char-to:\x3a%: TTY=%-:rest%
-rule=:%username:char-to:\x3a%: command not allowed %-:rest%
-rule=:%username:char-to:\x3a%: user NOT in sudoers %-:rest%
-rule=:%username:char-to:\x3a%: ignoring time stamp from the future %-:rest%
-rule=:%username:char-to:\x3a%: %-:number% incorrect password attempt ; %-:rest%
-rule=:%username:char-to:\x3a%: %-:number% incorrect password attempts %-:rest%
-rule=:%username:char-to:\x3a%: PWD=%-:rest%
+rule=: Successful su for %-:word% by %username:word%
+rule=: pam_unix(sudo:auth): authentication failure; logname= uid=%uid:number% euid=%-:number% %-:word% ruser= rhost=  user=%username:word%
+rule=: %username:char-to:\x3a%: TTY=%-:rest%
+rule=: %username:char-to:\x3a%: command not allowed %-:rest%
+rule=: %username:char-to:\x3a%: user NOT in sudoers %-:rest%
+rule=: %username:char-to:\x3a%: ignoring time stamp from the future %-:rest%
+rule=: %username:char-to:\x3a%: %-:number% incorrect password attempt ; %-:rest%
+rule=: %username:char-to:\x3a%: %-:number% incorrect password attempts %-:rest%
+rule=: %username:char-to:\x3a%: PWD=%-:rest%
 
 #*****************************************************************************
 # Rsync
 #*****************************************************************************
 
-rule=:auth failed on module %-:word% from %-:word% (%src-ip:char-to:\x29%): %-:rest%
+rule=: auth failed on module %-:word% from %-:word% (%src-ip:char-to:\x29%): %-:rest%
 
 #*****************************************************************************
 # VMWare (ESXi, etc)
 #*****************************************************************************
 
-rule=:Accepted password for %username:word% from %src-ip:ipv4%
+rule=: Accepted password for %username:word% from %src-ip:ipv4%
 #*****************************************************************************
 # Citrix
 #*****************************************************************************
 
 #  16:04:31 GMT server1 PPE-1 : AAA LOGIN_FAILED 71011157 :  User bob - Client_ip 12.12.12.12 - Failure_reason "External authentication server denied access"
 
-rule=:%-:word% %-:word% %-:word% %-:word% : AAA LOGIN_FAILED %-:word% :  User %username:word% - Client_ip %src-ip:ipv4% - Failure_reason %-:rest%
+rule=: %-:word% %-:word% %-:word% %-:word% : AAA LOGIN_FAILED %-:word% :  User %username:word% - Client_ip %src-ip:ipv4% - Failure_reason %-:rest%
 
 #  16:23:29 GMT server1 PPE-0 : SSLVPN LOGIN 75181906 : Context bob@12.12.12.12 - SessionId: 11147- User bob - Client_ip 12.12.12.12 - Nat_ip "Mapped Ip" - Vserver 192.168.1.1:443 - Browser_type "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)" - SSLVPN_client_type Clientless - Group(s) "N/A"
 
-rule=:%-:word% %-:word% %-:word% %-:word% : SSLVPN LOGIN %-:number% : Context %-:word% - SessionId: %-:word% User %username:word% - Client_ip %src-ip:ipv4% %-:rest%
-rule=:%-:word% %-:word% %-:word% %-:word% : SSLVPN LOGOUT %-:number% : Context %-:word% - SessionId: %-:word% User %username:word% - Client_ip %src-ip:ipv4% %-:rest%
+rule=: %-:word% %-:word% %-:word% %-:word% : SSLVPN LOGIN %-:number% : Context %-:word% - SessionId: %-:word% User %username:word% - Client_ip %src-ip:ipv4% %-:rest%
+rule=: %-:word% %-:word% %-:word% %-:word% : SSLVPN LOGOUT %-:number% : Context %-:word% - SessionId: %-:word% User %username:word% - Client_ip %src-ip:ipv4% %-:rest%
 
 # Palo Alto Firewall
 
 # 10.11.11.11|user|info|info|0e|2017-01-11|11:50:31|1,2017/01/28| 13:20:31,1009A101774,SYSTEM,general,0,2017/08/28 13:20:31,,general,,0,0,general,informational,User frank logged in via CLI from \ 10.1.9.3,891392,0x0,0,0,0,0,,XXXXXXXX-1
 
-rule=:%-:string-to:User%User %username:word% %-:char-to:\\%\ %src-ip:char-to:\x2c%%-:rest%
+rule=: %-:string-to:User%User %username:word% %-:char-to:\\%\ %src-ip:char-to:\x2c%%-:rest%
 
 # HP switches
 
 # 10.1.11.1|syslog|info|info|2e|2017-01-28|01:19:00|01342| auth: User 'frank' logged in from 10.1.1.1 to SSH session
 
-rule=:%-:string-to:User%User %username:word% logged in from %src-ip:ipv4% %-:rest%
+rule=: %-:string-to:User%User %username:word% logged in from %src-ip:ipv4% %-:rest%
 
 # Zscaler rule update
 
-rule=:act=Blocked%-:string-to:dst=%dst=%dst-ip:ipv4% src=%src-ip:ipv4%%-:string-to:suser=%suser=%username:char-to:\x40%%-:rest%
+rule=: act=Blocked%-:string-to:dst=%dst=%dst-ip:ipv4% src=%src-ip:ipv4%%-:string-to:suser=%suser=%username:char-to:\x40%%-:rest%
 
 #Cylance rule update
 
-rule=:%-:string-to:Event Type:%Event Type: Threat%-:string-to:Device Name:%Device Name: %username:char-to:\x2D%%-:char-to:\x28%(%src-ip:char-to:\x29%%-:rest%
+rule=: %-:string-to:Event Type:%Event Type: Threat%-:string-to:Device Name:%Device Name: %username:char-to:\x2D%%-:char-to:\x28%(%src-ip:char-to:\x29%%-:rest%
 
 #NPS IAS rule
 
-rule=:%-:string-to:IAS%%-:string-to:User-Name%%-:char-to:\x3E%>%username:char-to:\x3C%</User-Name><NAS-IP-Address data_type=%-:char-to:\x3E%>%src-ip:char-to:\x3C%%-:string-to:Calling-Station-Id%%-:char-to:\x3E%>%filename:char-to:\x3C%<%-:rest%
+rule=: %-:string-to:IAS%%-:string-to:User-Name%%-:char-to:\x3E%>%username:char-to:\x3C%</User-Name><NAS-IP-Address data_type=%-:char-to:\x3E%>%src-ip:char-to:\x3C%%-:string-to:Calling-Station-Id%%-:char-to:\x3E%>%filename:char-to:\x3C%<%-:rest%
 
 # SSH login
 #10.144.11.8|syslog|info|info|2e|2017-08-28|09:49:19|03362| auth: User 'XXXXXX' logged in from 10.10.10.10 to SSH session
 
-rule=:%-:string-to:User%User %username:word% logged in from %src-ip:ipv4% %-:rest%
+rule=: %-:string-to:User%User %username:word% logged in from %src-ip:ipv4% %-:rest%
 
 #10.78.11.51|user|info|info|0e|2017-08-28|13:20:31|1,2017/08/28| 13:20:31,0008C101111,SYSTEM,general,0,2017/08/28 13:20:31,,general,,0,0,general,informational,User XXXXXX logged in via CLI from \ j10.10.10.10,809792,0x0,0,0,0,0,,XXXXXX
 
-rule=:%-:string-to:User%User %username:word% %-:char-to:\\%\ %src-ip:char-to:\x2c%%-:rest%
+rule=: %-:string-to:User%User %username:word% %-:char-to:\\%\ %src-ip:char-to:\x2c%%-:rest%
 
 #*****************************************************************************
 # AS/400 rules (as400.rules)
 #*****************************************************************************
 
-rule=:iSecurity/Audit: %-:word% %-:word% *AUTFAIL An incorrect password was entered. User %username:word% %-:rest%
-rule=:iSecurity/Audit: %-:word% %-:word% *AUTFAIL User %username:word% %-:rest%
-rule=:iSecurity/Audit: %-:word% %-:word% *SECURITY User %username:word% %-:rest%
+rule=: iSecurity/Audit: %-:word% %-:word% *AUTFAIL An incorrect password was entered. User %username:word% %-:rest%
+rule=: iSecurity/Audit: %-:word% %-:word% *AUTFAIL User %username:word% %-:rest%
+rule=: iSecurity/Audit: %-:word% %-:word% *SECURITY User %username:word% %-:rest%
 
 #*****************************************************************************
 # TACACS
 #*****************************************************************************
 
-rule=:TACACS+ Client: Authentication error. Server is %DSTIP:ipv4%, user name is '%username:char-to:\x27%', remote address is %src-ip:ipv4%. %-:rest%
+rule=: TACACS+ Client: Authentication error. Server is %DSTIP:ipv4%, user name is '%username:char-to:\x27%', remote address is %src-ip:ipv4%. %-:rest%
 
 
 #*****************************************************************************
@@ -468,92 +468,92 @@ rule=:TACACS+ Client: Authentication error. Server is %DSTIP:ipv4%, user name is
 
 # 1006: The share denied access to the client
 
-rule=:1006: The share denied access to the client. Client Name: %clientname:word% Client Address: %clientaddress:ipv4%:%-:number% User Name: %username:string-to: Session ID% Session ID: %-:word% Share Name: %sharename:string-to: Share Path% Share Path: %sharepath:string-to: Status% Status: %status:string-to: Mapped Access% Mapped Access%-:rest%
+rule=: 1006: The share denied access to the client. Client Name: %clientname:word% Client Address: %clientaddress:ipv4%:%-:number% User Name: %username:string-to: Session ID% Session ID: %-:word% Share Name: %sharename:string-to: Share Path% Share Path: %sharepath:string-to: Status% Status: %status:string-to: Mapped Access% Mapped Access%-:rest%
 
 # 18456:
 
-rule=:%eventid:word% Login failed for user '%username:char-to:\x27%'. Reason: Could not find a login matching the name provided. [CLIENT: %src-ip:ipv4%]
+rule=: %eventid:word% Login failed for user '%username:char-to:\x27%'. Reason: Could not find a login matching the name provided. [CLIENT: %src-ip:ipv4%]
 
 # Account logged on - Windows event id 4624
 #10.41.43.253|user|info|info|0e|2017-08-28|13:02:55|Security| 4624: An account was successfully logged on. Subject: Security ID: S-1-0-0 Account Name: - Account Domain: - Logon ID: 0x0 Logon Type: 3 Impersonation Level: Impersonation New Logon: Security ID: S-1-5-21-2466666666-3858666666-3953666666-130966 Account Name: xxxx Account Domain: XXXXXX Logon ID: 0x5A31095D Logon GUID: {55555555-5555-5553-6666-966666666666} Process Information: Process ID: 0x0 Process Name: - Network Information: Workstation Name: - Source Network Address: 10.10.10.10 Source Port: 52526 Detailed Authentication Information: Logon Process: Kerberos Authentication Package: Kerberos Transited Services: - Package Name (NTLM only): - Key Length: 0 This event is generated when a logon session is created. It is generated on the computer that was accessed. The subject fields indicate the account on the local system which requested the logon. This is most commonly a service such as the Server service, or a local process such as Winlogon.exe or Services.exe. The logon type field indicates the kind of logon that occurred. The most common types are 2 (interactive) and 3 (network). The New Logon fields indicate the account for whom the new logon was created, i.e. the account that was logged on. The network fields indicate where a remote logon request originated. Workstation name is not always available and may be left blank in some cases. The impersonation level field indicates the extent to which a process in the logon session can impersonate. The authentication information fields provide detailed information about this specific logon request. - Logon GUID is a unique identifier that can be used to correlate this event with a KDC event. - Transited services indicate which intermediate services have participated in this logon request. - Package name indicates which sub-protocol was used among the NTLM protocols. - Key length indicates the length of the generated session key. This will be 0 if no session key was requested.
 
-rule=:%-:string-to:Account Name:%Account Name: %-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Network Address:%Network Address: %src-ip:ipv4% %-:rest%
-rule=:%-:string-to:Account Name:%Account Name: %-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Network Address:%Network Address: %src-ip:ipv4% %-:rest%
+rule=: %-:string-to:Account Name:%Account Name: %-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Network Address:%Network Address: %src-ip:ipv4% %-:rest%
+rule=: %-:string-to:Account Name:%Account Name: %-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Network Address:%Network Address: %src-ip:ipv4% %-:rest%
 
 # New normalization rules from Sam Castellango (2017/11/07)
 
 # This is for Microsoft Windows event 4624:
 
-rule=:%-:string-to:Account Name:%Account Name: %-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Network Address:%Network Address: %src-ip:ipv4% %-:rest%
+rule=: %-:string-to:Account Name:%Account Name: %-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Network Address:%Network Address: %src-ip:ipv4% %-:rest%
 
 #4662: An operation was performed on an object. Subject : Security ID: S-1-5-21-1848214942-2750813456-1026469966-108143 Account Name: WHarding Account Domain: GATE Logon ID: 0xB7F85337 Object: Object Server: DS Object Type: %{bf967aba-0de6-11d0-a285-00aa003049e2} Object Name: %{2a873ae7-98ad-441f-9cad-4f7dd7a1a9c8} Handle ID: 0x0 Operation: Operation Type: Object Access Accesses: READ_CONTROL Access Mask: 0x20000 Properties: READ_CONTROL {bf967aba-0de6-11d0-a285-00aa003049e2} Additional Information: Parameter 1: - Parameter 2:
-rule=:4662: An operation was performed on an object. Subject : Security ID: %-:word% Account Name: %username:word% %-:rest%
-rule=:4662: An operation was performed on an object. Subject : Security ID: %-:word% Account Name: %username:word% %-:rest%
+rule=: 4662: An operation was performed on an object. Subject : Security ID: %-:word% Account Name: %username:word% %-:rest%
+rule=: 4662: An operation was performed on an object. Subject : Security ID: %-:word% Account Name: %username:word% %-:rest%
 
 # 4724: An attempt was made to reset an account's password
 
-rule=:4724: An attempt was made to reset an account's password. Subject: Security ID: %subject-sid:word% Account Name: %subject-account:string-to: Account Domain% Account Domain: %-:word% Logon ID: %-:word% Target Account: Security ID: %target-sid:word% Account Name: %username:string-to: Account Domain% Account Domain: %-:rest%
+rule=: 4724: An attempt was made to reset an account's password. Subject: Security ID: %subject-sid:word% Account Name: %subject-account:string-to: Account Domain% Account Domain: %-:word% Logon ID: %-:word% Target Account: Security ID: %target-sid:word% Account Name: %username:string-to: Account Domain% Account Domain: %-:rest%
 
 # Windows Account Lockout: There are 2 rules for the first log. The idea is if there is a caller computer both rules will fire off and the 2nd rule will just not have a caller computer name. If there is not a caller computer, only rule 2 will fire and rule 1 will not work... in theory
 
 #4740: A user account was locked out. Subject: Security ID: S-1-5-18 Account Name: XXXXX$ Account Domain: XXXXXX Logon ID: 0x3E7 Account That Was Locked Out: Security ID: S-1-5-21-2455855555-3858555555-3953555555-55555 Account Name: XXXXX Additional Information: Caller Computer Name: XXXXXX
 
 #Rule 1
-rule=:4740: A user account was locked out. %-:string-to:Locked Out%%-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Computer Name:%Computer Name: %computername:word%
+rule=: 4740: A user account was locked out. %-:string-to:Locked Out%%-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Computer Name:%Computer Name: %computername:word%
 
 #Rule 2
-rule=:4740: A user account was locked out. %-:string-to:Locked Out%%-:string-to:Account Name:%Account Name: %username:word% %-:rest%
+rule=: 4740: A user account was locked out. %-:string-to:Locked Out%%-:string-to:Account Name:%Account Name: %username:word% %-:rest%
 
 #Kerberos ticket request
 #10.21.8.10.log:10.21.8.10|user|info|info|0e|2017-08-30|10:16:31|Security| 4769: A Kerberos service ticket was requested. Account Information: Account Name: XXX@XXXXX Account Domain: XXXXXX Logon GUID: {B7666966-6666-6666-6666-666666666666} Service Information: Service Name: XXXXXX$ Service ID: S-1-5-21-1716666666-1105666666-319566666-1166666 Network Information: Client Address: ::ffff:172.27.1.1 Client Port: 49350 Additional Information: Ticket Options: 0x40810000 Ticket Encryption Type: 0x12 Failure Code: 0x0 Transited Services: - This event is generated every time access is requested to a resource such as a computer or a Windows service. The service name indicates the resource to which access was requested. This event can be correlated with Windows logon events by comparing the Logon GUID fields in each event. The logon event occurs on the machine that was accessed, which is often a different machine than the domain controller which issued the service ticket. Ticket options, encryption types, and failure codes are defined in RFC 4120.
 
-rule=:%-:string-to:Account Name:%Account Name: %username:char-to:\x40%%-:string-to:Client Address:%Client Address: ::ffff:%src-ip:ipv4% %-:rest%
+rule=: %-:string-to:Account Name:%Account Name: %username:char-to:\x40%%-:string-to:Client Address:%Client Address: ::ffff:%src-ip:ipv4% %-:rest%
 
 # 4771: - IPv4 in IPv6
 
-rule=:%eventid:word% Kerberos pre-authentication failed. Account Information: Security ID: %ID:word% Account Name: %username:word% Service Information: Service Name: %-:word% Network Information: Client Address: ::ffff:%src-ip:ipv4% Client Port: %src-port:number% %-:rest%
+rule=: %eventid:word% Kerberos pre-authentication failed. Account Information: Security ID: %ID:word% Account Name: %username:word% Service Information: Service Name: %-:word% Network Information: Client Address: ::ffff:%src-ip:ipv4% Client Port: %src-port:number% %-:rest%
 
 # 4771: -IPv4
 
-rule=:%eventid:word% Kerberos pre-authentication failed. Account Information: Security ID: %ID:word% Account Name: %username:word% Service Information: Service Name: %-:word% Network Information: Client Address: %src-ip:ipv4% Client Port: %src-port:number% %-:rest%
+rule=: %eventid:word% Kerberos pre-authentication failed. Account Information: Security ID: %ID:word% Account Name: %username:word% Service Information: Service Name: %-:word% Network Information: Client Address: %src-ip:ipv4% Client Port: %src-port:number% %-:rest%
 
 # 4771: - IPv6
 
-rule=:%eventid:word% Kerberos pre-authentication failed. Account Information: Security ID: %ID:word% Account Name: %username:word% Service Information: Service Name: %-:word% Network Information: Client Address: %src-ip:ipv6% Client Port: %src-port:number% %-:rest%
+rule=: %eventid:word% Kerberos pre-authentication failed. Account Information: Security ID: %ID:word% Account Name: %username:word% Service Information: Service Name: %-:word% Network Information: Client Address: %src-ip:ipv6% Client Port: %src-port:number% %-:rest%
 
 # 4773
-rule=:4733: A member was removed from a security-enabled local group. Subject: Security ID: %subject-sid:word% Account Name: %subject-account:word% Account Domain: %subject-domain:word% Logon ID: %subject-logonid:word% Member: Security ID: %target-sid:word% Account Name: %target-account:word% Group: Security ID: %group-sid:word% Group Name: %group-name:word% %-:rest%
+rule=: 4733: A member was removed from a security-enabled local group. Subject: Security ID: %subject-sid:word% Account Name: %subject-account:word% Account Domain: %subject-domain:word% Logon ID: %subject-logonid:word% Member: Security ID: %target-sid:word% Account Name: %target-account:word% Group: Security ID: %group-sid:word% Group Name: %group-name:word% %-:rest%
 
 # 4776:
 
-rule=:%eventid:word% The computer attempted to validate the credentials for an account. Authentication Package: %-:word% Logon Account: %username:word% Source Workstation: %device:word% %-:rest%
+rule=: %eventid:word% The computer attempted to validate the credentials for an account. Authentication Package: %-:word% Logon Account: %username:word% Source Workstation: %device:word% %-:rest%
 
-rule=:%-:word% A user account was unlocked. Subject: Security ID: %-:word% Account Name: %username:word% %-:rest%
+rule=: %-:word% A user account was unlocked. Subject: Security ID: %-:word% Account Name: %username:word% %-:rest%
 
 # This is for Microsoft Windows event 4769:
 
-rule=:%-:string-to:Account Name:%Account Name: %username:char-to:\x40%%-:string-to:Client Address:%Client Address: ::ffff:%src-ip:ipv4% %-:rest%
+rule=: %-:string-to:Account Name:%Account Name: %username:char-to:\x40%%-:string-to:Client Address:%Client Address: ::ffff:%src-ip:ipv4% %-:rest%
 
 # 5136: A directory service object was modified
 
-rule=:5136: A directory service object was modified. Subject: Security ID: %subject-sid:word% Account Name: %subject-account:word% Account Domain: %subject-domain:word% Logon ID: %-:word% Directory Service: Name: %-:word% Type: Active Directory Domain Services Object: DN: %username:string-to: GUID% GUID: %-:word% Class: %-:word% Attribute: LDAP Display Name: %attribute:string-to: Syntax% Syntax (OID): %-:word% Value: %value:string-to: Operation% Operation: %-:rest%
+rule=: 5136: A directory service object was modified. Subject: Security ID: %subject-sid:word% Account Name: %subject-account:word% Account Domain: %subject-domain:word% Logon ID: %-:word% Directory Service: Name: %-:word% Type: Active Directory Domain Services Object: DN: %username:string-to: GUID% GUID: %-:word% Class: %-:word% Attribute: LDAP Display Name: %attribute:string-to: Syntax% Syntax (OID): %-:word% Value: %value:string-to: Operation% Operation: %-:rest%
 
 # 5145: A network share object was checked...
-rule=:5145: A network share object was checked to see whether client can be granted desired access. Subject: Security ID: %securityID:word% Account Name: %username:word% Account Domain: %-:word% Logon ID: %-:word% Network Information: Object Type: File Source Address: %src-ip:ipv4% Source Port: %string:number%%-:rest%
-rule=:5145: A network share object was checked to see whether client can be granted desired access. Subject: Security ID: %securityID:word% Account Name: %username:word% Account Domain: %-:word% Logon ID: %-:word% Network Information: Object Type: File Source Address: %src-ip:ipv4% Source Port: %string:number%%-:rest%
+rule=: 5145: A network share object was checked to see whether client can be granted desired access. Subject: Security ID: %securityID:word% Account Name: %username:word% Account Domain: %-:word% Logon ID: %-:word% Network Information: Object Type: File Source Address: %src-ip:ipv4% Source Port: %string:number%%-:rest%
+rule=: 5145: A network share object was checked to see whether client can be granted desired access. Subject: Security ID: %securityID:word% Account Name: %username:word% Account Domain: %-:word% Logon ID: %-:word% Network Information: Object Type: File Source Address: %src-ip:ipv4% Source Port: %string:number%%-:rest%
 
 # Added 2017/02/06
 
 # These for Microsoft Windows events 6272: and 6273:
 #6273: Network Policy Server denied access to a user.
 
-rule=:%-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Called Station Identifier:%Called Station Identifier: %nasMAC:char-to  :\ x3a%:%-:string-to:Calling Station Identifier:%Calling Station Identifier: %userMAC:char-to  :\ x20% %-:string-to:NAS IPv4 Address:%NAS IPv4 Address: %nasIP:ipv4% %-:string-to:NAS Identifier:%NAS Identifier: %nasHost:word% %-:string-to:Reason Code:%Reason Code: %reasonCode:word% %-:rest%
+rule=: %-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Called Station Identifier:%Called Station Identifier: %nasMAC:char-to  :\ x3a%:%-:string-to:Calling Station Identifier:%Calling Station Identifier: %userMAC:char-to  :\ x20% %-:string-to:NAS IPv4 Address:%NAS IPv4 Address: %nasIP:ipv4% %-:string-to:NAS Identifier:%NAS Identifier: %nasHost:word% %-:string-to:Reason Code:%Reason Code: %reasonCode:word% %-:rest%
 
-rule=:6273: Network Policy Server denied access to a user. Contact the Network Policy Server administrator for more information. User: Security ID: %securityid:word% Account Name: %username:word% Account Domain: %rest%
+rule=: 6273: Network Policy Server denied access to a user. Contact the Network Policy Server administrator for more information. User: Security ID: %securityid:word% Account Name: %username:word% Account Domain: %rest%
 
 #6272: Network Policy Server granted access to a user
 
-rule=:%-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Called Station Identifier:%Called Station Identifier: %nasMAC:char-to  :\ x3a%:%-:string-to:Calling Station Identifier:%Calling Station Identifier: %userMAC:char-to  :\ x20% %-:string-to:NAS IPv4 Address:%NAS IPv4 Address: %nasIP:ipv4% %-:string-to:NAS Identifier:%NAS Identifier: %nasHost:word% %-:string-to:Result:%Result: %reasonCode:word% %-:rest%
+rule=: %-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Called Station Identifier:%Called Station Identifier: %nasMAC:char-to  :\ x3a%:%-:string-to:Calling Station Identifier:%Calling Station Identifier: %userMAC:char-to  :\ x20% %-:string-to:NAS IPv4 Address:%NAS IPv4 Address: %nasIP:ipv4% %-:string-to:NAS Identifier:%NAS Identifier: %nasHost:word% %-:string-to:Result:%Result: %reasonCode:word% %-:rest%
 
 #*****************************************************************************
 # Microsoft Windows (via Evt2sys or NXLog)
@@ -561,60 +561,60 @@ rule=:%-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Call
 
 # Note the space at the end!
 #
-#rule=:529: NT AUTHORITY\\SYSTEM: Logon Failure: Reason: Unknown user name or bad password User Name: %username:word% Domain: %-:word% Logon Type: 3 Logon Process: NtLmSsp Authentication Package: NTLM Workstation Name: %-:word% Caller User Name: - Caller Domain: - Caller Logon ID: - Caller Process ID: - Transited Services: - Source Network Address: %src-ip:ipv4% Source Port: %src-port:number%
+#rule=: 529: NT AUTHORITY\\SYSTEM: Logon Failure: Reason: Unknown user name or bad password User Name: %username:word% Domain: %-:word% Logon Type: 3 Logon Process: NtLmSsp Authentication Package: NTLM Workstation Name: %-:word% Caller User Name: - Caller Domain: - Caller Logon ID: - Caller Process ID: - Transited Services: - Source Network Address: %src-ip:ipv4% Source Port: %src-port:number%
 
-#rule=:529: S-1-5-18: Logon Failure: Reason: Unknown user name or bad password User Name: %username:word% Domain: %-:word% Logon Type: 3 Logon Process: NtLmSsp Authentication Package: NTLM Workstation Name: %-:word% Caller User Name: - Caller Domain: - Caller Logon ID: - Caller Process ID: - Transited Services: - Source Network Address: %src-ip:ipv4% Source Port: %src-port:number%
+#rule=: 529: S-1-5-18: Logon Failure: Reason: Unknown user name or bad password User Name: %username:word% Domain: %-:word% Logon Type: 3 Logon Process: NtLmSsp Authentication Package: NTLM Workstation Name: %-:word% Caller User Name: - Caller Domain: - Caller Logon ID: - Caller Process ID: - Transited Services: - Source Network Address: %src-ip:ipv4% Source Port: %src-port:number%
 
 # PAM
 
-rule=:PAM %-:number% more authentication failures; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv4%  user=%username:word%
-rule=:PAM %-:number% more authentication failures; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv6%  user=%username:word%
-rule=:PAM %-:number% more authentication failure; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv4%  user=%username:word%
-rule=:PAM %-:number% more authentication failure; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv6%  user=%username:word%
+rule=: PAM %-:number% more authentication failures; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv4%  user=%username:word%
+rule=: PAM %-:number% more authentication failures; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv6%  user=%username:word%
+rule=: PAM %-:number% more authentication failure; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv4%  user=%username:word%
+rule=: PAM %-:number% more authentication failure; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv6%  user=%username:word%
 
-rule=:error: PAM: Authentication failure for %username:word% from %src-ip:ipv6%
+rule=: error: PAM: Authentication failure for %username:word% from %src-ip:ipv6%
 
 
-rule=:{"app_name": %-:string-to:"ipaddr%"ipaddr": "%src-ip:ipv4%"%-:string-to:"actor_user_id%"actor_user_id": %username:word%%-:rest% 
+rule=: {"app_name": %-:string-to:"ipaddr%"ipaddr": "%src-ip:ipv4%"%-:string-to:"actor_user_id%"actor_user_id": %username:word%%-:rest% 
 
 
 #This rule is used to parse the username within GCP Cloud Login Failure
-rule=:%-:string-to:method%method":"google.login.LoginService.loginFailure%-:string-to:principalEmail%principalEmail":%username:quoted-string%%-:rest%
+rule=: %-:string-to:method%method":"google.login.LoginService.loginFailure%-:string-to:principalEmail%principalEmail":%username:quoted-string%%-:rest%
 
 #This rule is used to parse URLs within Fortinet logs
-rule=:%-:string-to:url%url=%url:quoted-string%%-:rest%
+rule=: %-:string-to:url%url=%url:quoted-string%%-:rest%
 
 ###############                                                                                                                  # SentinelOne #
 ###############
 
 # Champ Clark III / 2022-08-16
 
-rule=:%-:word%   %-:word% -  %-:char-to:\x7c%|%-:char-to:\x7c%|%-:char-to:\x7c%|%os:char-to:\x7c%|%avtivitytype:char-to:\x7c%|New Suspicious threat detected - machine %machine:char-to:\x7c%|%-:rest%
-rule=:%-:word%   %-:word% -  %-:char-to:\x7c%|%-:char-to:\x7c%|%-:char-to:\x7c%|%os:char-to:\x7c%|%avtivitytype:char-to:\x7c%|New active threat - machine %machine:char-to:\x7c%|%-:rest%
+rule=: %-:word%   %-:word% -  %-:char-to:\x7c%|%-:char-to:\x7c%|%-:char-to:\x7c%|%os:char-to:\x7c%|%avtivitytype:char-to:\x7c%|New Suspicious threat detected - machine %machine:char-to:\x7c%|%-:rest%
+rule=: %-:word%   %-:word% -  %-:char-to:\x7c%|%-:char-to:\x7c%|%-:char-to:\x7c%|%os:char-to:\x7c%|%avtivitytype:char-to:\x7c%|New active threat - machine %machine:char-to:\x7c%|%-:rest%
 
 #Citrix Netscaler LOGIN LOGIN_FAILED
 #
 # 14:25:55 GMT StoreFront 0-PPE-0 : default SSLVPN LOGIN 1756256761 0 : Context rsolo003@10.32.2.21 - SessionId: 1590264 - User rsolo003 - Client_ip 10.32.2.21 - Nat_ip "Mapped Ip" - Vserver 10.15.152.104:443 - Browser_type "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36" - SSLVPN_client_type ICA - Group(s) "N/A"
 
 # 14:25:39 GMT StoreFront 0-PPE-0 : default AAA LOGIN_FAILED 1756254084 0 :  User rsolo003 - Client_ip 10.32.2.21 - Failure_reason "External authentication server denied access" - Browser Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36
-rule=:%timestamp:time-24hr% GMT %-:word% %-:number%-PPE-%-:number% : default SSLVPN %event_id:word% %epoch_time:number% %-:number% : %-:word% %username:char-to:\x40%@%src-ip:ipv4%%-:string-to:Vserver%Vserver %dst-ip:ipv4%:%-:rest%
+rule=: %timestamp:time-24hr% GMT %-:word% %-:number%-PPE-%-:number% : default SSLVPN %event_id:word% %epoch_time:number% %-:number% : %-:word% %username:char-to:\x40%@%src-ip:ipv4%%-:string-to:Vserver%Vserver %dst-ip:ipv4%:%-:rest%
 
 #*****************************************************************************
 # Netwrix
 #*****************************************************************************
 
 # 25407: DataSource : Logon Activity Action : Failed Logon Message: Failed Logon Logon Where : XXXX ObjectType : Logon Who : XXuserXX What : N/A When : 2022-11-01T23:03:12Z Workstation : XXworkstationXX Details : Cause: Pre-authentication information was invalid: usually means bad password., This entry represents 2 matching events occurring within 600 seconds.
-rule=:%-:number%: DataSource : Logon Activity Action : Failed Logon Message: Failed Logon Logon Where : %server:word% ObjectType : Logon Who : %-:char-to:\%\%username:word% What : N/A When : %-:date-iso%T%-:time-24hr%Z Workstation : %hostname:word% Details%-:rest%
+rule=: %-:number%: DataSource : Logon Activity Action : Failed Logon Message: Failed Logon Logon Where : %server:word% ObjectType : Logon Who : %-:char-to:\%\%username:word% What : N/A When : %-:date-iso%T%-:time-24hr%Z Workstation : %hostname:word% Details%-:rest%
 
 #*****************************************************************************
 # Sagan 
 #*****************************************************************************
 
-rule=:TRACK-CLIENT-LOGS - The IP address %src-ip:ipv4% was previously not sending logs. %-:rest%
-rule=:TRACK-CLIENT-LOGS - The IP address %src-ip:ipv6% was previously not sending logs. %-:rest%
+rule=: TRACK-CLIENT-LOGS - The IP address %src-ip:ipv4% was previously not sending logs. %-:rest%
+rule=: TRACK-CLIENT-LOGS - The IP address %src-ip:ipv6% was previously not sending logs. %-:rest%
 
-rule=:TRACK-CLIENT-NOLOGS - Logs have not been received from IP address %src-ip:ipv4% in over %-:number% minutes. %-:rest%
-rule=:TRACK-CLIENT-NOLOGS - Logs have not been received from IP address %src-ip:ipv6% in over %-:number% minutes. %-:rest%
+rule=: TRACK-CLIENT-NOLOGS - Logs have not been received from IP address %src-ip:ipv4% in over %-:number% minutes. %-:rest%
+rule=: TRACK-CLIENT-NOLOGS - Logs have not been received from IP address %src-ip:ipv6% in over %-:number% minutes. %-:rest%
 
 #*****************************************************************************
 # CrowdStrike
@@ -623,12 +623,12 @@ rule=:TRACK-CLIENT-NOLOGS - Logs have not been received from IP address %src-ip:
 #127.0.0.1|user|notice|notice|host|2023-05-02T10:15:36Z|2023-05-02T10:15:36+00:00|CEF|
 # 0|CrowdStrike|FalconHost|1.0|Incidents|1|cat=Incidents cs1Label=incidentType cs1=UNUSUAL_ACTIVITY severityNameLabel=severityName severityName=INFO msg=User access patterns detected as anomalous. Such activities may indicate potential threats such as endpoint infection, compromised account or other risks. Falcon monitors the activity and will escalate severity or incident type when necessary. deviceCustomDate1Label=startTime deviceCustomDate1=May 02 2023 10:15:35 deviceCustomDate2Label=endTime deviceCustomDate2=1683022536087 cs2Label=identityProtectionIncidentId cs2=INC-17533 duser=XXXX cs3Label=endpointIp cn1Label=numberOfCompromisedEntities cn1=1 cn2Label=numbersOfAlerts cn2=1 cs4Label=falconHostLink cs4=https://falcon.us-2.crowdstrike.com/XXXX stateLabel=state state=NEW
 
-rule=:0|%-:char-to:\x7c%|FalconHost|1.0|Incidents|1|cat=Incidents cs1Label=%-:word% cs1=%-:word% severityNameLabel=%-:word% severityName=%-:word% msg=%-:string-to:cs2=%cs2=%username:char-to:\x20%%-:rest%
+rule=: 0|%-:char-to:\x7c%|FalconHost|1.0|Incidents|1|cat=Incidents cs1Label=%-:word% cs1=%-:word% severityNameLabel=%-:word% severityName=%-:word% msg=%-:string-to:cs2=%cs2=%username:char-to:\x20%%-:rest%
 
 #Pulls message and username in Crowdstrike Falcon message
-rule=:0|CrowdStrike|FalconHost|%-:string-to:msg%msg=%message:char-to:\x2e%%-:string-to:duser%duser=%username:word%%-:rest%
+rule=: 0|CrowdStrike|FalconHost|%-:string-to:msg%msg=%message:char-to:\x2e%%-:string-to:duser%duser=%username:word%%-:rest%
 
 #SonicWall IPS Prevention Log Normalization
 #Pulls Message, SRC IP and DSTIP
-rule=:sn=%-:string-to:msg%msg=%message:quoted-string%%-:string-to:src%src=%src_ip:ipv4%:%-:string-to:dst%dst=%dest_ip:ipv4%:%-:rest%
+rule=: sn=%-:string-to:msg%msg=%message:quoted-string%%-:string-to:src%src=%src_ip:ipv4%:%-:string-to:dst%dst=%dest_ip:ipv4%:%-:rest%
 


### PR DESCRIPTION
All normalization rules used by Sagan require a space at the beginning of the rule (after rule=:) and before the actual log message due to how Sagan processes logs.