### PR TITLE
Add experimental Zscaler ZIA/ZPA JSON feed rules and dynamic-load tri…

### DIFF
--- a/.last_used_sid
+++ b/.last_used_sid
@@ -1,2 +1,2 @@
-Normal Rule: 5017933
+Normal Rule: 5017935
 Fingerprint: 5100196

--- a/dynamic.rules
+++ b/dynamic.rules
@@ -280,3 +280,5 @@ alert any any any -> any any (msg:"[DYNAMIC] Windows OWA Logs Detected"; content
 alert any any any -> any any (msg:"[DYNAMIC] Zeek Logs Detected"; program:bro|zeek; dynamic_load: $RULE_PATH/zeeks.rules; classtype:dynamic-rules; sid:5017359; rev:1;)
 alert any any any -> any any (msg:"[DYNAMIC] Mimecast V2 Logs Detected"; program:mimecast; dynamic_load: $RULE_PATH/mimecast_v2.rules; classtype:dynamic-rules; sid:5017382; rev:1;)
 alert any any any -> any any (msg:"[DYNAMIC] Sophos Firewall Logs Detected"; program:sophos; dynamic_load: $RULE_PATH/sophos_firewall.rules; classtype:dynamic-rules; sid:5017456; rev:1;)
+alert any any any -> any any (msg:"[DYNAMIC][EXPERIMENTAL] Zscaler ZIA Logs Detected"; program:Zscaler; dynamic_load: $RULE_PATH/zscaler-zia.rules; classtype:dynamic-rules; sid:5017934; rev:1;)
+alert any any any -> any any (msg:"[DYNAMIC][EXPERIMENTAL] Zscaler ZPA Logs Detected"; program:Zscaler; dynamic_load: $RULE_PATH/zscaler-zpa.rules; classtype:dynamic-rules; sid:5017935; rev:1;)

--- a/zscaler-zia-bluedot.rules
+++ b/zscaler-zia-bluedot.rules
@@ -1,0 +1,42 @@
+# Sagan zscaler-zia-bluedot.rules
+# Copyright (c) 2009-2026. Quadrant Information Security <www.quadrantsec.com>
+# All rights reserved.
+#
+# Please submit any custom rules or ideas to sagan-submit@quadrantsec.com or the sagan-sigs mailing list
+#
+#*************************************************************
+#  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+#  following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+#    disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+#    following disclaimer in the documentation and/or other materials provided with the distribution.
+#  * Neither the name of the nor the names of its contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES,
+#  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+#  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#*************************************************************
+
+# Bluedot IP-reputation checks for the ZIA NSS Web JSON feed (see zscaler-zia.rules for feed
+# format / prerequisites). Checks the DESTINATION server IP (event.serverip) the client's egress
+# request actually reached -- one SID per reputation category, matching the existing
+# cisco-bluedot.rules / openssh-bluedot.rules house pattern, so each category can be tuned and
+# triaged independently. Each is suppressed to one alert per destination IP per 2 hours (same
+# window as the existing zscaler-bluedot.rules / cisco-bluedot.rules), so a sustained session to
+# the same bad IP doesn't reproduce.
+#
+# DRAFT SIDs: local/unallocated 9000020-9000029 block. Renumber before merging into production.
+
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA-BLUEDOT][EXPERIMENTAL] Outbound connection to Malicious IP"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_map: "dest_ip", ".event.serverip"; json_map: "src_ip", ".event.ClientIP"; json_map: "username", ".event.user"; bluedot: type ip_reputation, track by_dst, mdate_effective_period 1 months, Malicious; threshold: type suppress, track by_dst, count 1, seconds 7200; classtype: trojan-activity; sid:9000020; rev:1; metadata: mitre_tactic_id TA0011, mitre_technique_id T1071, created_at 2026_08_11, updated_at 2026_08_11;)
+
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA-BLUEDOT][EXPERIMENTAL] Outbound connection to Tor exit node"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_map: "dest_ip", ".event.serverip"; json_map: "src_ip", ".event.ClientIP"; json_map: "username", ".event.user"; bluedot: type ip_reputation, track by_dst, mdate_effective_period 1 months, Tor; threshold: type suppress, track by_dst, count 1, seconds 7200; classtype: suspicious-traffic; sid:9000021; rev:1; metadata: mitre_tactic_id TA0011, mitre_technique_id T1090.003, created_at 2026_08_11, updated_at 2026_08_11;)
+
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA-BLUEDOT][EXPERIMENTAL] Outbound connection to open Proxy IP"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_map: "dest_ip", ".event.serverip"; json_map: "src_ip", ".event.ClientIP"; json_map: "username", ".event.user"; bluedot: type ip_reputation, track by_dst, mdate_effective_period 1 months, Proxy; threshold: type suppress, track by_dst, count 1, seconds 7200; classtype: suspicious-traffic; sid:9000022; rev:1; metadata: mitre_tactic_id TA0011, mitre_technique_id T1090, created_at 2026_08_11, updated_at 2026_08_11;)

--- a/zscaler-zia.rules
+++ b/zscaler-zia.rules
@@ -1,0 +1,145 @@
+# Sagan zscaler-zia.rules
+# Copyright (c) 2009-2026. Quadrant Information Security <www.quadrantsec.com>
+# All rights reserved.
+#
+# Please submit any custom rules or ideas to sagan-submit@quadrantsec.com or the sagan-sigs mailing list
+#
+#*************************************************************
+#  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+#  following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+#    disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+#    following disclaimer in the documentation and/or other materials provided with the distribution.
+#  * Neither the name of the nor the names of its contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES,
+#  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+#  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#*************************************************************
+
+# Rules for Zscaler Internet Access (ZIA) NSS Web feed delivered as a JSON blob inside the
+# syslog "message" field (sourcetype "zscalernss-web"), e.g.:
+#
+#   <srcip>|<facility>|<priority>|<level>||<time>|<date>|Zscaler| {"sourcetype":"zscalernss-web","event.vendor":"Zscaler",...}
+#
+# This is a DIFFERENT feed/format than the older CEF-based zscaler.rules / zscaler-bluedot.rules
+# in this ruleset (those expect `program: CEF` and `act=Allowed` style content). These rules
+# require `parse-json-message: enabled` in sagan.yaml (see the Sagan JSON documentation) --
+# no changes to json-input.map / json-message.map are needed since every field is accessed
+# inline via json_content: / json_map:.
+#
+# DRAFT SIDs: this file uses the local/unallocated 9000001-9000019 block. Renumber against your
+# real SID registry before merging into a production ruleset.
+#
+# IMPORTANT -- two different "client IP" fields exist in this feed and are NOT interchangeable:
+#   event.clientpublicIP  = the org's NAT'd/shared egress IP (a handful of values org-wide)
+#   event.ClientIP        = the actual per-endpoint internal IP (one per workstation)
+# All src_ip mapping below intentionally uses event.ClientIP. Using clientpublicIP for
+# threshold/suppression tracking would merge every user behind the same egress IP into one
+# bucket and silently break per-user dedup.
+#
+# NOTE on outside-home-country (OHM): intentionally NOT included in this file. ZIA is raw web
+# proxy telemetry with no login/session concept and no reliable per-request identity-to-geo
+# binding -- an OHM rule here would fire on every remote/traveling employee's ordinary browsing.
+# OHM is implemented on the ZPA feed instead (zscaler-zpa-geoip.rules), where access is
+# authenticated and per-session. Bluedot IP-reputation checks for this feed live in
+# zscaler-zia-bluedot.rules.
+#
+# NOTE on field grounding: this file was originally built against one week of real ZIA traffic
+# that contained zero live threat/DLP hits (threatname, threatclass, dlpengine and
+# unscannabletype were "None" on every row). The enum values used below were subsequently
+# verified against Zscaler's own published NSS Web Logs field reference
+# (help.zscaler.com/zia/nss-feed-output-format-web-logs) and URL category reference
+# (help.zscaler.com/zia/about-url-categories) rather than guessed -- see the per-rule comments.
+# Two rules from the first draft of this file (unscannabletype and known-bad-category) used
+# incorrect enum values that don't actually exist in Zscaler's taxonomy; both are corrected here
+# (rev bumped to 2). Still worth a final sanity check against your own tenant before enabling,
+# since no positive example of any of these fired in the sample data.
+
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA][EXPERIMENTAL] Malware download blocked by Advanced Threat Protection"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_content:".event.action","Blocked"; json_content:!".event.threatname","None"; json_map: "src_ip", ".event.ClientIP"; json_map: "dest_ip", ".event.serverip"; json_map: "username", ".event.user"; threshold: type suppress, track by_src, count 1, seconds 3600; classtype: malware; sid:9000001; rev:1; metadata: mitre_tactic_id TA0011, mitre_technique_id T1105, created_at 2026_08_11, updated_at 2026_08_11;)
+
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA][EXPERIMENTAL] DLP policy violation detected on outbound transfer"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_content:!".event.dlpengine","None"; json_map: "src_ip", ".event.ClientIP"; json_map: "dest_ip", ".event.serverip"; json_map: "username", ".event.user"; threshold: type suppress, track by_src, count 1, seconds 3600; classtype: exfiltration; sid:9000002; rev:1; metadata: mitre_tactic_id TA0010, mitre_technique_id T1567, created_at 2026_08_11, updated_at 2026_08_11;)
+
+# CORRECTED (rev 2): Zscaler's NSS Web Logs reference documents exactly 3 unscannabletype
+# values -- "Encrypted File", "Undetectable File", "Unscannable File" (password-protected /
+# corrupt / oversized content are described as examples *within* those 3 buckets, not separate
+# enum values as the first draft of this rule assumed). Matching "not None" is now equivalent to
+# matching all 3 and needs no guesswork. Content that bypassed AV/sandbox inspection is a classic
+# malware-staging evasion technique regardless of which of the 3 buckets it falls in.
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA][EXPERIMENTAL] Unscannable content transferred (possible AV/sandbox evasion)"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_content:".event.action","Allowed"; json_content:!".event.unscannabletype","None"; json_map: "src_ip", ".event.ClientIP"; json_map: "dest_ip", ".event.serverip"; json_map: "username", ".event.user"; threshold: type suppress, track by_src, count 1, seconds 3600; classtype: evasion; sid:9000003; rev:2; metadata: mitre_tactic_id TA0005, mitre_technique_id T1027, created_at 2026_08_11, updated_at 2026_08_11;)
+
+# CORRECTED (rev 2): the first draft of this rule matched "Phishing"/"Botnet"/"Malicious
+# Content"/etc as urlcategory values -- those are NOT in Zscaler's base URL-category taxonomy.
+# The documented "Security" supercategory only has 4 subcategories (End-to-End Encrypted
+# Content, Malicious TLDs, Other Security, Spyware/Adware); malicious-verdict categories like
+# Phishing/Botnet live in a separate Advanced Threat Protection policy dimension, which this
+# feed surfaces via threatname/threatclass (see the ATP-verdict rules below), not urlcategory.
+# Rebuilt on the two genuinely-documented narrow URL categories that ARE meaningful to flag when
+# ALLOWED: newly-registered domains (<30 days old, still uncategorized -- common early
+# phishing/C2 infrastructure) and malicious TLDs. Category display strings can vary slightly by
+# tenant/category-DB version (our own sample shows Zscaler sometimes surfaces raw
+# code-style names verbatim, e.g. "United_Whitelist_URL_Category" was seen as a literal
+# urlcategory value) -- this pattern matches both the human-readable and raw code-style forms;
+# verify against your tenant before enabling.
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA][EXPERIMENTAL] Newly-registered domain or malicious TLD allowed"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_content:".event.action","Allowed"; json_pcre:".event.urlcategory","/newly.?reg(istered)?.?domains?|malicious.?tlds?/i"; json_map: "src_ip", ".event.ClientIP"; json_map: "dest_ip", ".event.serverip"; json_map: "username", ".event.user"; threshold: type suppress, track by_src, count 1, seconds 3600; classtype: policy-violation; sid:9000004; rev:2; metadata: mitre_tactic_id TA0011, mitre_technique_id T1071.001, created_at 2026_08_11, updated_at 2026_08_11;)
+
+# "Blocked" alone is not a security signal in this feed -- 51/55 Blocked rows in the sample were
+# "Dropped due to failed client SSL handshake" (routine TLS noise). Only the explicit firewall
+# policy reason below is a real enforcement event, so the reason string is required, not just action.
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA][EXPERIMENTAL] Application blocked by firewall policy"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_content:".event.action","Blocked"; json_content:".event.reason","Web application is blocked by Firewall rule"; json_map: "src_ip", ".event.ClientIP"; json_map: "username", ".event.user"; threshold: type suppress, track by_src&by_username, count 1, seconds 3600; classtype: policy-violation; sid:9000005; rev:1; metadata: mitre_tactic_id TA0011, mitre_technique_id T1071, created_at 2026_08_11, updated_at 2026_08_11;)
+
+# NEW: Zscaler's sandbox/behavioral-detonation engine verdict (documented threatclass value,
+# distinct from signature-based malware detection covered by SID 9000001) -- co-firing with
+# 9000001 on the same event is expected/intentional here (this rule adds the more specific
+# "this was a behavioral/sandbox verdict, not a signature match" triage tag, it isn't meant to
+# replace the generic rule).
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA][EXPERIMENTAL] Sandbox behavioral-analysis threat blocked"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_content:".event.action","Blocked"; json_content:".event.threatclass","Behavior Analysis"; json_map: "src_ip", ".event.ClientIP"; json_map: "dest_ip", ".event.serverip"; json_map: "username", ".event.user"; threshold: type suppress, track by_src, count 1, seconds 3600; classtype: malware; sid:9000006; rev:1; metadata: mitre_tactic_id TA0002, mitre_technique_id T1204.002, created_at 2026_08_11, updated_at 2026_08_11;)
+
+# NEW: threatname sub-classification for prioritization -- cryptomining malware specifically
+# (distinct triage/impact profile from generic malware).
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA][EXPERIMENTAL] Cryptomining malware blocked"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_content:".event.action","Blocked"; json_pcre:".event.threatname","/miner/i"; json_map: "src_ip", ".event.ClientIP"; json_map: "dest_ip", ".event.serverip"; json_map: "username", ".event.user"; threshold: type suppress, track by_src, count 1, seconds 3600; classtype: coin-mining; sid:9000007; rev:1; metadata: mitre_tactic_id TA0040, mitre_technique_id T1496, created_at 2026_08_11, updated_at 2026_08_11;)
+
+# NEW: threatname sub-classification -- phishing content blocked by the ATP engine itself
+# (distinct from SID 9000004, which is a category-based allow-through gap; this is an active
+# engine-confirmed phishing verdict).
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA][EXPERIMENTAL] Phishing threat blocked"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_content:".event.action","Blocked"; json_pcre:".event.threatname","/^HTML\.Phish/i"; json_map: "src_ip", ".event.ClientIP"; json_map: "dest_ip", ".event.serverip"; json_map: "username", ".event.user"; threshold: type suppress, track by_src, count 1, seconds 3600; classtype: phish; sid:9000008; rev:1; metadata: mitre_tactic_id TA0001, mitre_technique_id T1566.002, created_at 2026_08_11, updated_at 2026_08_11;)
+
+# NEW: threatname sub-classification -- scam destination blocked.
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA][EXPERIMENTAL] Scam destination blocked"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_content:".event.action","Blocked"; json_pcre:".event.threatname","/scam/i"; json_map: "src_ip", ".event.ClientIP"; json_map: "dest_ip", ".event.serverip"; json_map: "username", ".event.user"; threshold: type suppress, track by_src, count 1, seconds 3600; classtype: social-engineering; sid:9000009; rev:1; metadata: mitre_tactic_id TA0001, mitre_technique_id T1566, created_at 2026_08_11, updated_at 2026_08_11;)
+
+# NEW: risky script/executable extension downloaded regardless of the threat engine's verdict
+# (based on Splunk ESCU's "Potentially Abused File Download" analytic, deliberately narrowed).
+# ESCU's public version also flags .dll and .bat -- both dropped here since they're extremely
+# common in legitimate software installs/update packages and admin scripts in most enterprise
+# environments; including them would make this noisy rather than high-fidelity. Kept only the
+# extensions that are rare in ordinary business web traffic and disproportionately used in
+# initial-access payloads (screensaver droppers, HTA/VBS/JScript/WSF downloaders, malicious
+# shortcut files, CHM help-file smuggling). No action= filter by design -- the value here is
+# catching risky files the threat engine hasn't (yet) flagged, so it intentionally also matches
+# "Allowed" events.
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZIA][EXPERIMENTAL] Risky script/executable file extension downloaded"; program: Zscaler; json_content:".sourcetype","zscalernss-web"; json_pcre:".event.url","/\.(scr|lnk|hta|vbs|jse|wsf|chm)([\?&]|$)/i"; json_map: "src_ip", ".event.ClientIP"; json_map: "dest_ip", ".event.serverip"; json_map: "username", ".event.user"; threshold: type suppress, track by_src, count 1, seconds 3600; classtype: suspicious-filename-detect; sid:9000010; rev:1; metadata: mitre_tactic_id TA0011, mitre_technique_id T1105, created_at 2026_08_11, updated_at 2026_08_11;)
+
+# NOT IMPLEMENTED -- recommended feed/telemetry expansion, not a rule gap:
+# This customer's current NSS Web export does not include Zscaler's domain-fronting
+# (df_hostname/df_hosthead SNI-vs-Host-header mismatch), SSL-inspection-exemption
+# (externalspr), PAC-vs-Client-Connector forwarding method (trafficredirectmethod), or explicit
+# Client-Connector-bypass (bypassed_traffic) fields -- all documented, all narrow/high-fidelity
+# signals (domain fronting and proxy-bypass in particular have near-zero legitimate-traffic
+# overlap), but none of them exist in the current field export for this feed, so no rule can be
+# written against them today. Recommend asking the customer to add these fields to their NSS
+# Web feed output template if domain-fronting/proxy-bypass detection is wanted.
+#
+# Separately, ZIA also publishes distinct Cloud Firewall (non-HTTP, port/protocol-level) and DNS
+# NSS feeds (help.zscaler.com/zia/nss-feed-output-format-firewall-logs and
+# .../nss-feed-output-format-dns-logs) with port-scan/beaconing and DNS-tunneling/DGA detection
+# potential -- this customer is only sending the Web feed (sourcetype zscalernss-web). No rules
+# are written against those feeds since we have never seen a single line of that data; this is a
+# collection-gap recommendation, not something these rules can compensate for.

--- a/zscaler-zpa-bluedot.rules
+++ b/zscaler-zpa-bluedot.rules
@@ -1,0 +1,43 @@
+# Sagan zscaler-zpa-bluedot.rules
+# Copyright (c) 2009-2026. Quadrant Information Security <www.quadrantsec.com>
+# All rights reserved.
+#
+# Please submit any custom rules or ideas to sagan-submit@quadrantsec.com or the sagan-sigs mailing list
+#
+#*************************************************************
+#  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+#  following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+#    disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+#    following disclaimer in the documentation and/or other materials provided with the distribution.
+#  * Neither the name of the nor the names of its contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES,
+#  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+#  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#*************************************************************
+
+# Bluedot IP-reputation checks for the ZPA LSS connection-log feed (see zscaler-zpa.rules for
+# feed format / prerequisites). Checks the CLIENT public IP (ClientPublicIP) -- is this private
+# application access originating from known-malicious/Tor/proxy infrastructure? One SID per
+# reputation category (same house pattern as zscaler-zia-bluedot.rules / cisco-bluedot.rules),
+# suppressed to one alert per source IP per 2 hours.
+#
+# Scoped to ConnectionStatus "open" and excludes "ZPA LSS Client" (Zscaler's own log-shipping
+# service account -- see zscaler-zpa-geoip.rules for why) for the same reasons as the OHM rule.
+#
+# DRAFT SIDs: local/unallocated 9000050-9000059 block. Renumber before merging into production.
+
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg:"[ZSCALER-ZPA-BLUEDOT][EXPERIMENTAL] Private app access from a known Malicious IP"; program: Zscaler; json_content:".ConnectionStatus","open"; content:!"ZPA LSS Client"; json_map: "src_ip", ".ClientPublicIP"; json_map: "dest_ip", ".ServerIP"; json_map: "username", ".Username"; bluedot: type ip_reputation, track by_src, mdate_effective_period 1 months, Malicious; threshold: type suppress, track by_src, count 1, seconds 7200; classtype: trojan-activity; sid:9000050; rev:1; metadata: mitre_tactic_id TA0011, mitre_technique_id T1071, created_at 2026_08_11, updated_at 2026_08_11;)
+
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg:"[ZSCALER-ZPA-BLUEDOT][EXPERIMENTAL] Private app access from a Tor exit node"; program: Zscaler; json_content:".ConnectionStatus","open"; content:!"ZPA LSS Client"; json_map: "src_ip", ".ClientPublicIP"; json_map: "dest_ip", ".ServerIP"; json_map: "username", ".Username"; bluedot: type ip_reputation, track by_src, mdate_effective_period 1 months, Tor; threshold: type suppress, track by_src, count 1, seconds 7200; classtype: suspicious-traffic; sid:9000051; rev:1; metadata: mitre_tactic_id TA0011, mitre_technique_id T1090.003, created_at 2026_08_11, updated_at 2026_08_11;)
+
+alert any $EXTERNAL_NET any -> $HOME_NET any (msg:"[ZSCALER-ZPA-BLUEDOT][EXPERIMENTAL] Private app access from an open Proxy IP"; program: Zscaler; json_content:".ConnectionStatus","open"; content:!"ZPA LSS Client"; json_map: "src_ip", ".ClientPublicIP"; json_map: "dest_ip", ".ServerIP"; json_map: "username", ".Username"; bluedot: type ip_reputation, track by_src, mdate_effective_period 1 months, Proxy; threshold: type suppress, track by_src, count 1, seconds 7200; classtype: suspicious-traffic; sid:9000052; rev:1; metadata: mitre_tactic_id TA0011, mitre_technique_id T1090, created_at 2026_08_11, updated_at 2026_08_11;)

--- a/zscaler-zpa-geoip.rules
+++ b/zscaler-zpa-geoip.rules
@@ -1,0 +1,51 @@
+# Sagan zscaler-zpa-geoip.rules
+# Copyright (c) 2009-2026. Quadrant Information Security <www.quadrantsec.com>
+# All rights reserved.
+#
+# Please submit any custom rules or ideas to sagan-submit@quadrantsec.com or the sagan-sigs mailing list
+#
+#*************************************************************
+#  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+#  following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+#    disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+#    following disclaimer in the documentation and/or other materials provided with the distribution.
+#  * Neither the name of the nor the names of its contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES,
+#  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+#  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#*************************************************************
+
+# Outside-Home-Country (OHM) rule for the ZPA LSS connection-log feed (see zscaler-zpa.rules for
+# feed format / prerequisites). ZPA is the right home for OHM in this ruleset -- it's an
+# authenticated, per-user, per-session access event (unlike ZIA's raw web-proxy telemetry, which
+# has no login concept and would just fire on every traveling employee's browsing). Same idiom
+# as the existing msapi-azuread-geoip.rules: GeoIP lookup via the country_code keyword against
+# the mapped src_ip, `isnot $HOME_COUNTRY`.
+#
+# Scoped to ConnectionStatus "open" only (the initial connection-establishment event) so a
+# single session doesn't generate one hit per log line (ZPA logs "open", "active", and "close"
+# rows for the same connection).
+#
+# CRITICAL FP GUARD: excludes "ZPA LSS Client" -- Zscaler's own Log Streaming Service account,
+# which legitimately ships these very logs from wherever the LSS publisher/broker sits and can
+# routinely appear "outside home country" for entirely benign infrastructure reasons (observed
+# doing exactly this in real customer data). Without this exclusion the rule free-fires on every
+# batch of shipped logs.
+#
+# Suppressed to one alert per user per source IP per day (matches the existing
+# msapi-azuread-geoip.rules convention) so a legitimate remote/traveling user generates one
+# alert per day of activity, not one per connection.
+#
+# DRAFT SID: local/unallocated 9000040-9000049 block. Renumber before merging into production.
+
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZPA-GEOIP][EXPERIMENTAL] Private application access from outside HOME_COUNTRY"; program: Zscaler; json_content:".ConnectionStatus","open"; content:!"ZPA LSS Client"; json_map: "src_ip", ".ClientPublicIP"; json_map: "dest_ip", ".ServerIP"; json_map: "username", ".Username"; country_code: track by_src, isnot $HOME_COUNTRY; threshold: type suppress, track by_src&by_username, count 1, seconds 86400; classtype: successful-user; sid:9000040; rev:1; metadata: mitre_tactic_id TA0001, mitre_technique_id T1078.004, created_at 2026_08_11, updated_at 2026_08_11;)

--- a/zscaler-zpa.rules
+++ b/zscaler-zpa.rules
@@ -1,0 +1,63 @@
+# Sagan zscaler-zpa.rules
+# Copyright (c) 2009-2026. Quadrant Information Security <www.quadrantsec.com>
+# All rights reserved.
+#
+# Please submit any custom rules or ideas to sagan-submit@quadrantsec.com or the sagan-sigs mailing list
+#
+#*************************************************************
+#  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+#  following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+#    disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+#    following disclaimer in the documentation and/or other materials provided with the distribution.
+#  * Neither the name of the nor the names of its contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES,
+#  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+#  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#*************************************************************
+
+# Rules for Zscaler Private Access (ZPA) Log Streaming Service (LSS) connection-log feed,
+# delivered as a JSON blob inside the syslog "message" field, e.g.:
+#
+#   <srcip>|<facility>|<priority>|<level>||<time>|<date>|Zscaler| {"LogTimestamp":"...","Customer":"...","Username":"user@domain","ClientPublicIP":"...","ClientCountryCode":"US","InternalReason":"OPEN_OR_ACTIVE_CONNECTION",...}
+#
+# Requires `parse-json-message: enabled` in sagan.yaml -- see zscaler-zia.rules header for the
+# same prerequisite note. No json-input.map / json-message.map changes needed; fields are
+# accessed inline via json_content: / json_map:.
+#
+# IMPORTANT -- "ZPA LSS Client" is Zscaler's own Log Streaming Service account shipping these
+# logs to our collection pipeline, NOT a human user. It legitimately connects from wherever the
+# LSS publisher happens to sit (observed from Germany in one real customer's feed while every
+# human user connected from North America) and will happily rack up "failures"/"denials" against
+# whatever internal syslog-relay app it targets if that app blips. Excluded below wherever a rule
+# tracks by username so it can't be mistaken for anomalous user behavior.
+#
+# DRAFT SIDs: local/unallocated 9000030-9000039 block. Renumber before merging into production.
+# Outside-home-country (OHM) and Bluedot IP-reputation checks for this feed live in the
+# companion zscaler-zpa-geoip.rules and zscaler-zpa-bluedot.rules files.
+
+# BRK_MT_SETUP_FAIL_NO_POLICY_FOUND is steady-state ZTNA policy-misconfiguration noise in real
+# deployments -- observed thousands of times over a week for 2 known users hitting one app with
+# no assigned access policy (a config problem to report separately, not necessarily an attack).
+# Sagan's legacy threshold keyword only supports "limit" and "suppress" (there is no Snort-style
+# "threshold" type) -- "suppress" fires on the first qualifying event, then goes silent for the
+# rest of the window *and resets that window on every further match*, so it only re-fires once a
+# genuine lull occurs. Verified against the real data: this collapses a multi-hour, 1300+ event
+# retry storm into a small handful of alerts (one per onset of a new episode) instead of firing
+# on every single denial.
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZPA][EXPERIMENTAL] Private application access denied (no matching policy)"; program: Zscaler; json_content:".InternalReason","BRK_MT_SETUP_FAIL_NO_POLICY_FOUND"; content:!"ZPA LSS Client"; json_map: "src_ip", ".ClientPublicIP"; json_map: "dest_ip", ".ServerIP"; json_map: "username", ".Username"; threshold: type suppress, track by_src&by_username, count 1, seconds 1800; classtype: reconnaissance; sid:9000030; rev:1; metadata: mitre_tactic_id TA0007, mitre_technique_id T1046, created_at 2026_08_11, updated_at 2026_08_11;)
+
+# Session/SAML setup failures (expired assertions, broker/connector setup errors, timeouts).
+# Excludes BRK_MT_SETUP_FAIL_NO_POLICY_FOUND, which is handled -- and suppressed differently --
+# by the rule above. Same "suppress" reasoning: fires on the first failure, then holds quiet
+# through a sustained cluster of retries, re-arming after a 30-minute lull.
+alert any $HOME_NET any -> $EXTERNAL_NET any (msg:"[ZSCALER-ZPA][EXPERIMENTAL] Private access session setup failure"; program: Zscaler; json_content:!".InternalReason","BRK_MT_SETUP_FAIL_NO_POLICY_FOUND"; json_pcre:".InternalReason","/SETUP_FAIL|SETUP_ERR|SETUP_TIMEOUT/"; content:!"ZPA LSS Client"; json_map: "src_ip", ".ClientPublicIP"; json_map: "username", ".Username"; threshold: type suppress, track by_username, count 1, seconds 1800; classtype: credential-access; sid:9000031; rev:1; metadata: mitre_tactic_id TA0006, mitre_technique_id T1556, created_at 2026_08_11, updated_at 2026_08_11;)


### PR DESCRIPTION
…ggers

New JSON-in-message feeds (ZIA NSS Web / ZPA LSS connection log) are a different format than the existing CEF-based zscaler.rules, so new files were added instead of touching that one. All rules are tagged [EXPERIMENTAL] pending validation against live traffic.

- zscaler-zia.rules: malware/DLP/evasion/policy content detections
- zscaler-zia-bluedot.rules: destination IP reputation
- zscaler-zpa.rules: policy-denied access and session/SAML failures
- zscaler-zpa-geoip.rules: outside-home-country (OHM) rule
- zscaler-zpa-bluedot.rules: client IP reputation
- dynamic.rules: program:Zscaler triggers to auto-load zscaler-zia.rules and zscaler-zpa.rules (sid:5017934/5017935)
- .last_used_sid: bumped Normal Rule counter to 5017935