### PR TITLE
Drop toggle from the validator's xbits actions

### DIFF
--- a/.github/scripts/validate_sagan_rules.py
+++ b/.github/scripts/validate_sagan_rules.py
@@ -37,7 +37,11 @@ VALID_RULE_OPTIONS = {
 VALID_RULE_TYPES   = {"alert", "drop", "pass"}
 VALID_PROTOCOLS    = {"any", "tcp", "udp", "icmp", "syslog"}
 VALID_PARSE_HASH   = {"md5", "sha1", "sha256"}
-VALID_XBIT_ACTIONS = {"set", "unset", "isset", "isnotset", "toggle", "noalert", "noeve"}
+# "toggle" is deliberately absent. Sagan's error message lists it and
+# src/rules.h still carries xbit_toggle_count, but the branch that would
+# honour it is commented out in src/rules.c, so xbit_type stays 0 and
+# Load_Rules() aborts. Accepting it here passes a rule the engine refuses.
+VALID_XBIT_ACTIONS = {"set", "unset", "isset", "isnotset", "noalert", "noeve"}
 VALID_XBIT_TRACK   = {"ip_src", "ip_dst", "ip_pair"}
 VALID_FLEXBIT_ACTIONS = {
     "noalert", "set", "unset", "isset", "isnotset",
@@ -420,7 +424,7 @@ def validate_rule(rule: str, lineno: int, filename: str) -> tuple[list[str], lis
                 action = rest.split(",")[0].strip()
                 if action not in VALID_XBIT_ACTIONS:
                     err(f"'xbits' action must be one of {sorted(VALID_XBIT_ACTIONS)}; got '{action}'")
-                elif action in ("set", "unset", "isset", "isnotset", "toggle"):
+                elif action in ("set", "unset", "isset", "isnotset"):
                     parts_xbit = [p.strip() for p in rest.split(",")]
                     if len(parts_xbit) < 3:
                         err(f"'xbits {action}' is incomplete — requires action,name,track by ...")


### PR DESCRIPTION
VALID_XBIT_ACTIONS lists "toggle", and validate_rule treats it as a full action alongside set and isset. Sagan does not accept it: the branch that would handle it is commented out in src/rules.c, inside a block opened around line 1250 with a note from 2019 saying the semantics were never settled. xbit_type is therefore never assigned, the check a few lines below sees 0, and Load_Rules() aborts.

A rule using it passes CI and then stops Sagan from starting:

    [E] [rules.c, line 1269] Xbit is not 'set', 'unset', 'isset',
        'isnotset' or 'toggle'. Abort at line 1 in <ruleset>

Two things point the wrong way here, which is worth a comment rather than a silent deletion. The engine's own error message lists toggle as valid, and src/rules.h still carries xbit_toggle_count. Only the parser decides, and it has the branch commented out.

No rule in the corpus uses toggle, so nothing is broken today; the gap only bites whoever writes one. The full ruleset still validates: 342 files, no errors.